### PR TITLE
Update booking event dates to Oct 29–31

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ MYSQL_USER = os.getenv("MYSQL_USER", "apec")
 MYSQL_PASSWORD = os.getenv("MYSQL_PASSWORD", "")
 
 # 이벤트/운영시간
-EVENT_DATES = ["2025-10-28", "2025-10-29", "2025-10-30"]
+EVENT_DATES = ["2025-10-29", "2025-10-30", "2025-10-31"]
 HOURS = list(range(9, 18))  # 09~18 보기(시작 슬롯은 9~17)
 MAX_BLOCKS = 2              # 1h/block, 최대 2블록 = 2시간
 

--- a/send_email.sh
+++ b/send_email.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # Usage:
-#   ./send_email.sh 20251028            # 실제 발송 (DRY_RUN=0일 때)
-#   DRY_RUN=1 ./send_email.sh 20251028  # 메일 미발송, 콘솔 미리보기
+#   ./send_email.sh 20251029            # 실제 발송 (DRY_RUN=0일 때)
+#   DRY_RUN=1 ./send_email.sh 20251029  # 메일 미발송, 콘솔 미리보기
 #
 # Requirements:
 #   - Python 3.x (email/smtplib 표준 라이브러리 사용)
@@ -26,7 +26,7 @@ ENV_FILE="${ENV_FILE:-/opt/apec-booking/.env}"
 DRY_RUN="${DRY_RUN:-0}"
 
 if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 yyyymmdd   (e.g., $0 20251028)"
+  echo "Usage: $0 yyyymmdd   (e.g., $0 20251029)"
   exit 1
 fi
 

--- a/static/booking.html
+++ b/static/booking.html
@@ -26,7 +26,7 @@
 <label>Blocks<select name="blocks" id="blocks"><option value="1">1 (60m)</option><option value="2">2 (120m)</option></select></label>
 <div></div>
 </div>
-<div class="muted" style="margin-top:6px">Operating hours 06:00–22:00 · Event window Oct 28–30</div>
+<div class="muted" style="margin-top:6px">Operating hours 06:00–22:00 · Event window Oct 29–31</div>
 <button type="submit" style="margin-top:10px">Submit booking</button>
 </form>
 <div id="msg" class="muted" style="margin-top:8px"></div>
@@ -35,7 +35,7 @@
 <script>
 const ROOM_LABEL = { 'Indoor-1':'Indoor 1','Indoor-2':'Indoor 2','Outdoor-1':'Outdoor 1','Indoor-3':'Indoor 3','Indoor-4':'Indoor 4','Outdoor-2':'Outdoor 2','Outdoor-3':'Outdoor 3','Outdoor-Annex':'Outdoor Annex','Indoor-5':'Indoor 5'};
 const ROOM_MAP = { 'Diamond':['Indoor-1','Indoor-2','Outdoor-1'], 'Platinum':['Indoor-3','Indoor-4','Outdoor-2'], 'Gold':['Outdoor-3','Outdoor-Annex'], 'General':['Indoor-5'] };
-const EVENT_START='2025-10-28', EVENT_END='2025-10-30';
+const EVENT_START='2025-10-29', EVENT_END='2025-10-31';
 
 
 function withinEvent(d){ return (d>=EVENT_START && d<=EVENT_END); }
@@ -72,7 +72,7 @@ fillTier(); fillRooms(); await refreshSlots();
 const form=document.getElementById('bookingForm');
 form.addEventListener('submit', async (e)=>{
 e.preventDefault(); const data=Object.fromEntries(new FormData(form).entries());
-if(!withinEvent(data.date)){ document.getElementById('msg').textContent='Date must be within Oct 28–30.'; return; }
+if(!withinEvent(data.date)){ document.getElementById('msg').textContent='Date must be within Oct 29–31.'; return; }
 const payload={ company:data.company.trim(), email:data.email.trim(), tier:data.tier, room_code:data.room_code, date:data.date, start_hour:parseInt(data.start_hour,10), blocks:parseInt(data.blocks,10) };
 try{
 const r = await fetch('/api/bookings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});

--- a/templates/1
+++ b/templates/1
@@ -61,7 +61,7 @@
 
       <label class="field">
         <span>Date</span>
-        <input required type="date" name="date" id="date" min="2025-10-28" max="2025-10-30" />
+        <input required type="date" name="date" id="date" min="2025-10-29" max="2025-10-31" />
       </label>
 
       <label class="field">
@@ -83,7 +83,7 @@
       </label>
 
       <div class="hint">
-        Operating hours <b>06:00–22:00</b> · Event <b>Oct 28–30</b> · Max consecutive blocks: <b>2</b>
+        Operating hours <b>06:00–22:00</b> · Event <b>Oct 29–31</b> · Max consecutive blocks: <b>2</b>
       </div>
 
       <button class="button primary" type="submit">Submit booking</button>

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -57,7 +57,7 @@
 
       <label class="field date-field" id="dateField">
         <span>Date</span>
-        <input required type="date" name="date" id="date" min="2025-10-28" max="2025-10-30" />
+        <input required type="date" name="date" id="date" min="2025-10-29" max="2025-10-31" />
         <button class="date-open-btn" type="button" id="openDate" aria-label="Open calendar">📅</button>
       </label>
 
@@ -86,7 +86,7 @@
       </label>
 
       <div class="hint" style="grid-column:1/-1">
-        Operating hours <b>09:00–18:00</b> · Event <b>Oct 28–30</b> · Max per day per company: <b>2 hours</b>
+        Operating hours <b>09:00–18:00</b> · Event <b>Oct 29–31</b> · Max per day per company: <b>2 hours</b>
       </div>
 
       <!-- ✅ 하루 2시간 제한 경고 -->


### PR DESCRIPTION
## Summary
- shift the configured event date list to October 29–31 for the booking backend
- align booking forms and static assets to the new Oct 29–31 window, including validation messaging
- refresh email script usage examples to reference the updated start date

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf914d3d5483238854b28096ed5868