### PR TITLE
Restyle top navigation heading

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -33,7 +33,22 @@ a:hover{text-decoration:underline}
 .topbar{position:sticky;top:0;z-index:20;background:#0c1422;box-shadow:var(--shadow)}
 .topbar-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:12px 16px}
 .brand{display:flex;align-items:center;gap:10px}
-.brand .title{font-weight:700;font-size:var(--fs-lg)}
+.brand .title{
+  display:flex;
+  flex-direction:column;
+  gap:2px;
+  line-height:1.15;
+}
+.brand .title .eyebrow{
+  font-size:var(--fs-sm);
+  letter-spacing:0.18em;
+  text-transform:uppercase;
+  color:var(--muted);
+}
+.brand .title .headline{
+  font-weight:800;
+  font-size:var(--fs-lg);
+}
 .nav .link{margin-left:12px;color:#c9d7f2}
 
 .wrap{max-width:1200px;margin:16px auto;padding:0 12px}

--- a/templates/1
+++ b/templates/1
@@ -28,7 +28,10 @@
   <div class="topbar-inner">
     <div class="brand">
       <img src="/static/logo-apec.svg" alt="APEC" />
-      <div class="title">APEC CEO Summit - Meeting Rooms</div>
+      <div class="title">
+        <span class="eyebrow">APEC CEO Summit</span>
+        <span class="headline">Meeting Rooms</span>
+      </div>
     </div>
     <nav class="nav">
       <a href="/launcher" class="link">Display</a>

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -24,7 +24,10 @@
   <div class="topbar-inner">
     <div class="brand">
       <img src="/static/logo-apec.svg" alt="APEC" />
-      <div class="title">APEC CEO Summit - Meeting Rooms</div>
+      <div class="title">
+        <span class="eyebrow">APEC CEO Summit</span>
+        <span class="headline">Meeting Rooms</span>
+      </div>
     </div>
     <nav class="nav">
       <a href="/launcher" class="link">Display</a>

--- a/templates/launcher.html
+++ b/templates/launcher.html
@@ -11,7 +11,10 @@
   <div class="topbar-inner">
     <div class="brand">
       <img src="/static/logo-apec.svg" alt="APEC" />
-      <div class="title">APEC CEO Summit - Meeting Rooms</div>
+      <div class="title">
+        <span class="eyebrow">APEC CEO Summit</span>
+        <span class="headline">Meeting Rooms</span>
+      </div>
     </div>
     <nav class="nav">
       <a href="/" class="link">Booking</a>


### PR DESCRIPTION
## Summary
- restyle the top navigation title on booking-related pages to present "APEC CEO Summit" and "Meeting Rooms" as a two-line lockup
- add supporting styles so the new eyebrow and headline typography render consistently across the shared header

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cf92c9da948323a17135635f5b9c28