### PR TITLE
Update favicon to summit icon

### DIFF
--- a/templates/1
+++ b/templates/1
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>APEC Meeting Rooms - Booking</title>
   <link rel="stylesheet" href="/static/style.css" />
-  <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+  <link rel="icon" type="image/x-icon" href="https://www.apecceosummitkorea2025.com/images/favicon.ico" />
 
 <!-- booking.html <head> 끝부분에 추가 -->
 <style>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>APEC Meeting Rooms - Admin</title>
   <link rel="stylesheet" href="/static/style.css" />
-  <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+  <link rel="icon" type="image/x-icon" href="https://www.apecceosummitkorea2025.com/images/favicon.ico" />
   <style>
     .toolbar{display:flex;gap:10px;flex-wrap:wrap;align-items:center;margin-bottom:10px}
     .toolbar .field{display:flex;flex-direction:column}

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>APEC Meeting Rooms - Booking</title>
   <link rel="stylesheet" href="/static/style.css" />
-  <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+  <link rel="icon" type="image/x-icon" href="https://www.apecceosummitkorea2025.com/images/favicon.ico" />
   <style>
     .date-field{position:relative}
     .date-open-btn{

--- a/templates/display.html
+++ b/templates/display.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>APEC – Display</title>
   <link rel="stylesheet" href="/static/style.css" />
-  <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+  <link rel="icon" type="image/x-icon" href="https://www.apecceosummitkorea2025.com/images/favicon.ico" />
 </head>
 <body>
 <header class="topbar">

--- a/templates/launcher.html
+++ b/templates/launcher.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>APEC Meeting Rooms - Display Launcher</title>
   <link rel="stylesheet" href="/static/style.css" />
+  <link rel="icon" type="image/x-icon" href="https://www.apecceosummitkorea2025.com/images/favicon.ico" />
 </head>
 <body>
 <header class="topbar">


### PR DESCRIPTION
## Summary
- point all HTML templates to the official APEC CEO Summit Korea 2025 favicon
- add the favicon link to the launcher view for consistent branding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfa3dc24a4832397b68cc71bd00640