### PR TITLE
Add room guide and adjust admin access

### DIFF
--- a/static/images/rooms/indoor-suite.svg
+++ b/static/images/rooms/indoor-suite.svg
@@ -1,0 +1,35 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1b2b48" />
+      <stop offset="100%" stop-color="#273b63" />
+    </linearGradient>
+    <linearGradient id="g2" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f9d976" />
+      <stop offset="100%" stop-color="#f39f86" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#g1)" rx="32" />
+  <g fill="none" stroke="#ffffff22" stroke-width="4">
+    <rect x="120" y="140" width="960" height="520" rx="28" />
+    <rect x="200" y="220" width="320" height="360" rx="20" />
+    <rect x="560" y="220" width="440" height="360" rx="24" />
+  </g>
+  <g>
+    <rect x="240" y="280" width="240" height="80" rx="14" fill="#f3f7ff" opacity="0.85" />
+    <rect x="240" y="380" width="240" height="80" rx="14" fill="#f3f7ff" opacity="0.65" />
+    <rect x="240" y="480" width="240" height="80" rx="14" fill="#f3f7ff" opacity="0.45" />
+  </g>
+  <g>
+    <rect x="620" y="260" width="360" height="220" rx="22" fill="#0f172a" opacity="0.9" />
+    <rect x="660" y="300" width="280" height="140" rx="18" fill="#101f36" />
+    <rect x="720" y="340" width="160" height="60" rx="12" fill="#182c4f" />
+  </g>
+  <circle cx="340" cy="240" r="46" fill="url(#g2)" opacity="0.85" />
+  <text x="600" y="640" text-anchor="middle" font-size="56" font-family="'Segoe UI',sans-serif" fill="#f6f9ff" opacity="0.92">
+    Indoor Meeting Suite
+  </text>
+  <text x="600" y="690" text-anchor="middle" font-size="26" font-family="'Segoe UI',sans-serif" fill="#c7d4f8" opacity="0.8">
+    Designed for executive boardroom sessions and hybrid collaboration
+  </text>
+</svg>

--- a/static/images/rooms/other-room.svg
+++ b/static/images/rooms/other-room.svg
@@ -1,0 +1,25 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#221f3b" />
+      <stop offset="100%" stop-color="#302d52" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#4facfe" />
+      <stop offset="100%" stop-color="#00f2fe" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" rx="32" fill="url(#bg)" />
+  <rect x="200" y="200" width="800" height="400" rx="36" fill="#0e1529" opacity="0.9" />
+  <rect x="260" y="260" width="320" height="120" rx="28" fill="#16223b" />
+  <rect x="260" y="420" width="320" height="120" rx="28" fill="#16223b" opacity="0.8" />
+  <rect x="620" y="260" width="280" height="280" rx="32" fill="#141f34" />
+  <rect x="660" y="300" width="200" height="200" rx="28" fill="url(#accent)" opacity="0.28" />
+  <rect x="700" y="340" width="120" height="120" rx="18" fill="url(#accent)" opacity="0.55" />
+  <text x="600" y="660" text-anchor="middle" font-size="54" font-family="'Segoe UI',sans-serif" fill="#f6f9ff" opacity="0.92">
+    Multi-purpose Collaboration Room
+  </text>
+  <text x="600" y="705" text-anchor="middle" font-size="26" font-family="'Segoe UI',sans-serif" fill="#c5d8ff" opacity="0.85">
+    A flexible canvas ready for bespoke experiences and private meetings
+  </text>
+</svg>

--- a/static/images/rooms/outdoor-terrace.svg
+++ b/static/images/rooms/outdoor-terrace.svg
@@ -1,0 +1,41 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#7fd1ff" />
+      <stop offset="100%" stop-color="#1e3f66" />
+    </linearGradient>
+    <linearGradient id="sunset" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ffedbc" />
+      <stop offset="100%" stop-color="#ed4264" />
+    </linearGradient>
+    <linearGradient id="deck" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3a2d20" />
+      <stop offset="100%" stop-color="#6b4f2d" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#sky)" rx="32" />
+  <circle cx="920" cy="160" r="120" fill="url(#sunset)" opacity="0.9" />
+  <g opacity="0.5">
+    <path d="M0 360 C200 320 400 360 600 340 C800 320 1000 360 1200 330 L1200 0 L0 0 Z" fill="#f6f9ff" />
+  </g>
+  <rect x="100" y="420" width="1000" height="260" rx="28" fill="#13233a" opacity="0.88" />
+  <rect x="140" y="520" width="320" height="120" rx="24" fill="url(#deck)" />
+  <rect x="560" y="500" width="220" height="160" rx="24" fill="#1b2f48" opacity="0.9" />
+  <rect x="820" y="500" width="220" height="160" rx="24" fill="#243f63" opacity="0.9" />
+  <g opacity="0.85">
+    <line x1="160" y1="520" x2="420" y2="520" stroke="#f7f1e3" stroke-width="6" stroke-linecap="round" />
+    <line x1="160" y1="560" x2="420" y2="560" stroke="#f7f1e3" stroke-width="6" stroke-linecap="round" />
+    <line x1="160" y1="600" x2="420" y2="600" stroke="#f7f1e3" stroke-width="6" stroke-linecap="round" />
+  </g>
+  <g opacity="0.25" fill="#ffffff">
+    <circle cx="240" cy="320" r="36" />
+    <circle cx="320" cy="280" r="24" />
+    <circle cx="380" cy="320" r="18" />
+  </g>
+  <text x="600" y="700" text-anchor="middle" font-size="56" font-family="'Segoe UI',sans-serif" fill="#f6f9ff" opacity="0.92">
+    Outdoor Skyline Terrace
+  </text>
+  <text x="600" y="744" text-anchor="middle" font-size="26" font-family="'Segoe UI',sans-serif" fill="#d6e6ff" opacity="0.85">
+    Sunset-ready venue with canopy lighting and premium lounge seating
+  </text>
+</svg>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -26,6 +26,7 @@
     <nav class="nav">
       <a href="/" class="link">Booking</a>
       <a href="/launcher" class="link">Display</a>
+      <a href="/rooms" class="link">Room Guide</a>
     </nav>
   </div>
 </header>

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -31,6 +31,7 @@
     </div>
     <nav class="nav">
       <a href="/launcher" class="link">Display</a>
+      <a href="/rooms" class="link">Room Guide</a>
       <a href="/admin" class="link">Admin</a>
     </nav>
   </div>

--- a/templates/display.html
+++ b/templates/display.html
@@ -16,6 +16,7 @@
     </div>
     <nav class="nav">
       <a href="/" class="link">Booking</a>
+      <a href="/rooms" class="link">Room Guide</a>
       <a href="/admin" class="link">Admin</a>
     </nav>
   </div>

--- a/templates/launcher.html
+++ b/templates/launcher.html
@@ -19,6 +19,7 @@
     </div>
     <nav class="nav">
       <a href="/" class="link">Booking</a>
+      <a href="/rooms" class="link">Room Guide</a>
       <a href="/admin" class="link">Admin</a>
     </nav>
   </div>

--- a/templates/room_detail.html
+++ b/templates/room_detail.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>{{ room_name }} - Room Details</title>
+  <link rel="stylesheet" href="/static/style.css" />
+  <link rel="icon" type="image/x-icon" href="https://www.apecceosummitkorea2025.com/images/favicon.ico" />
+  <style>
+    .hero{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:24px;align-items:center}
+    .hero img{width:100%;border-radius:var(--radius);border:1px solid var(--line);box-shadow:var(--shadow)}
+    .feature-list{display:flex;flex-wrap:wrap;gap:10px;margin:0;padding:0;list-style:none}
+    .feature-list li{border:1px solid var(--line);border-radius:999px;padding:8px 14px;background:#101a2c}
+    .info-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;margin-top:20px}
+    .info-card{background:#101a2c;border:1px solid var(--line);border-radius:var(--radius);padding:16px;box-shadow:var(--shadow)}
+  </style>
+</head>
+<body>
+<header class="topbar">
+  <div class="topbar-inner">
+    <div class="brand">
+      <img src="/static/logo-apec.svg" alt="APEC" />
+      <div class="title">
+        <span class="eyebrow">APEC CEO Summit</span>
+        <span class="headline">Meeting Rooms</span>
+      </div>
+    </div>
+    <nav class="nav">
+      <a href="/" class="link">Booking</a>
+      <a href="/launcher" class="link">Display</a>
+      <a href="/rooms" class="link">Room Guide</a>
+      <a href="/admin" class="link">Admin</a>
+    </nav>
+  </div>
+</header>
+
+<main class="wrap">
+  <section class="card">
+    <a href="/rooms" class="muted" style="display:inline-flex;align-items:center;gap:6px;margin-bottom:12px">← Back to rooms</a>
+    <div class="hero">
+      <img src="{{ details.image }}" alt="{{ room_name }}" loading="lazy" />
+      <div>
+        <h1 class="title" style="margin-bottom:12px">{{ room_name }}</h1>
+        <p class="muted" style="margin:0 0 16px">{{ details.summary }}</p>
+        <ul class="feature-list">
+          {% for feature in details.features %}
+          <li>{{ feature }}</li>
+          {% endfor %}
+        </ul>
+        <div style="margin-top:16px">
+          <span class="pill">Capacity: {{ details.capacity }} pax</span>
+          <span class="pill" style="margin-left:10px">Code: {{ room_code }}</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2 class="title">Plan your meeting</h2>
+    <div class="info-grid">
+      <div class="info-card">
+        <h3 style="margin-top:0">Best for</h3>
+        <p class="muted">High-touch engagements, leadership sessions and partner briefings.</p>
+      </div>
+      <div class="info-card">
+        <h3 style="margin-top:0">Setup options</h3>
+        <p class="muted">Boardroom, classroom or lounge layout. Concierge team can reset the room within 15 minutes.</p>
+      </div>
+      <div class="info-card">
+        <h3 style="margin-top:0">Connectivity</h3>
+        <p class="muted">High-bandwidth Wi-Fi, HDMI/USB-C presentation hub and dedicated AV technician support.</p>
+      </div>
+    </div>
+    <div style="margin-top:24px;display:flex;flex-wrap:wrap;gap:12px">
+      <a class="button" href="/">Book this room</a>
+      <a class="button" href="/display?room={{ room_code }}&date={{ schedule_date }}">View live schedule</a>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/templates/rooms.html
+++ b/templates/rooms.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>APEC Meeting Rooms - Room Guide</title>
+  <link rel="stylesheet" href="/static/style.css" />
+  <link rel="icon" type="image/x-icon" href="https://www.apecceosummitkorea2025.com/images/favicon.ico" />
+  <style>
+    .room-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:20px;margin-top:20px}
+    .room-card{display:flex;flex-direction:column;background:var(--card);border:1px solid var(--line);border-radius:var(--radius);overflow:hidden;box-shadow:var(--shadow)}
+    .room-card img{width:100%;height:180px;object-fit:cover;background:#091120}
+    .room-card-body{padding:16px;display:flex;flex-direction:column;gap:12px}
+    .room-card h3{margin:0;font-size:var(--fs-lg)}
+    .room-meta{display:flex;gap:12px;flex-wrap:wrap;font-size:var(--fs-sm);color:var(--muted)}
+    .room-features{display:flex;flex-wrap:wrap;gap:8px}
+    .chip-small{border:1px solid var(--line);border-radius:999px;padding:6px 10px;font-size:var(--fs-xs,13px);color:#c9d7f2}
+    .room-card-footer{margin-top:auto;display:flex;justify-content:flex-end}
+  </style>
+</head>
+<body>
+<header class="topbar">
+  <div class="topbar-inner">
+    <div class="brand">
+      <img src="/static/logo-apec.svg" alt="APEC" />
+      <div class="title">
+        <span class="eyebrow">APEC CEO Summit</span>
+        <span class="headline">Meeting Rooms</span>
+      </div>
+    </div>
+    <nav class="nav">
+      <a href="/" class="link">Booking</a>
+      <a href="/launcher" class="link">Display</a>
+      <a href="/admin" class="link">Admin</a>
+    </nav>
+  </div>
+</header>
+
+<main class="wrap">
+  <section class="card">
+    <h1 class="title">Room Guide</h1>
+    <p class="muted">Explore the meeting rooms curated for APEC CEO Summit delegations. Tap a room to see detailed amenities and images.</p>
+    <div class="room-grid">
+      {% for room in rooms %}
+      <article class="room-card">
+        <img src="{{ room.image }}" alt="{{ room.name }}" loading="lazy" />
+        <div class="room-card-body">
+          <h3>{{ room.name }}</h3>
+          <div class="room-meta">
+            <span>Capacity: {{ room.capacity }} pax</span>
+            <span>Code: {{ room.code }}</span>
+          </div>
+          <p class="muted" style="margin:0">{{ room.summary }}</p>
+          <div class="room-features">
+            {% for feature in room.features %}
+            <span class="chip-small">{{ feature }}</span>
+            {% endfor %}
+          </div>
+          <div class="room-card-footer">
+            <a class="button" href="/rooms/{{ room.code }}">View details</a>
+          </div>
+        </div>
+      </article>
+      {% endfor %}
+    </div>
+  </section>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- default the FastAPI service to port 80 and expose dedicated room guide and admin routes
- add room overview and detailed description pages with illustrative images and booking/display shortcuts
- link the new guide across booking, display, launcher and admin navigation for quick access

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68cfa53865ec8323a7a8ed871e0293b5