### PR TITLE
Document CAP_NET_BIND_SERVICE requirements

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -35,6 +35,8 @@ Restart=always
 RestartSec=3
 
 # (선택) 기본 하드닝
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 NoNewPrivileges=true
 PrivateTmp=true
 


### PR DESCRIPTION
## Summary
- document the need for CAP_NET_BIND_SERVICE ambient/capability bounding set in the systemd unit example

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfb5475be483238c598bcbee61e5a1