### PR TITLE
Update navigation to prioritize booking page

### DIFF
--- a/app.py
+++ b/app.py
@@ -381,6 +381,11 @@ def display_page(request: Request, room: str, date: str):
 
 
 @app.get("/", response_class=HTMLResponse)
+def redirect_to_booking() -> RedirectResponse:
+    """Serve the booking page as the default landing screen."""
+    return RedirectResponse(url="/booking", status_code=302)
+
+
 @app.get("/rooms", response_class=HTMLResponse)
 def rooms_overview(request: Request):
     """Grouped overview of rooms by sponsor tier."""

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -24,8 +24,6 @@
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>
     <nav class="nav">
-      <a href="/" class="link">Room Guide</a>
-      <a href="/booking" class="link">Booking</a>
       <a href="/launcher" class="link">Display</a>
     </nav>
   </div>

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -37,9 +37,7 @@
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>
     <nav class="nav">
-      <a href="/" class="link">Room Guide</a>
-      <a href="/launcher" class="link">Display</a>
-      <a href="/admin" class="link">Admin</a>
+      <a href="/rooms" class="button">Room Guide</a>
     </nav>
   </div>
 </header>

--- a/templates/display.html
+++ b/templates/display.html
@@ -15,8 +15,6 @@
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>
     <nav class="nav">
-      <a href="/" class="link">Room Guide</a>
-      <a href="/booking" class="link">Booking</a>
       <a href="/admin" class="link">Admin</a>
     </nav>
   </div>

--- a/templates/launcher.html
+++ b/templates/launcher.html
@@ -15,8 +15,6 @@
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>
     <nav class="nav">
-      <a href="/" class="link">Room Guide</a>
-      <a href="/booking" class="link">Booking</a>
       <a href="/admin" class="link">Admin</a>
     </nav>
   </div>

--- a/templates/rooms.html
+++ b/templates/rooms.html
@@ -98,7 +98,7 @@
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>
     <nav class="nav">
-      <a href="/booking" class="link">Booking</a>
+      <a href="/booking" class="button">Back to Booking</a>
     </nav>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- redirect the root URL to the booking view so it loads by default
- update booking and room guide headers so they only link to each other and show the room guide button
- limit admin and display headers to only link to each other per requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfc90bc7508323b47a0e13633aef6c