### PR TITLE
Sanitize room and company inputs before booking

### DIFF
--- a/app.py
+++ b/app.py
@@ -447,6 +447,9 @@ def create_booking(
     blocks: int = Form(...),
     company_other: str | None = Form(None),  # Other일 때 수동 입력
 ):
+    company = (company or "").strip()
+    room = (room or "").strip()
+
     if date not in EVENT_DATES:
         raise HTTPException(status_code=400, detail="Invalid date")
     if room not in ROOM_LABEL:


### PR DESCRIPTION
## Summary
- trim incoming company and room values in the booking endpoint
- prevent foreign key errors caused by whitespace in submitted room codes

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68cfcfabfe808323863313c959f432f2