### PR TITLE
Ensure launcher tiers follow sponsor priority

### DIFF
--- a/app.py
+++ b/app.py
@@ -381,7 +381,13 @@ def booking_page(request: Request):
 def launcher_page(request: Request):
     return templates.TemplateResponse(
         "launcher.html",
-        dict(request=request, event_dates=EVENT_DATES, rooms_by_tier=ROOMS_BY_TIER, room_label=ROOM_LABEL),
+        dict(
+            request=request,
+            event_dates=EVENT_DATES,
+            rooms_by_tier=ROOMS_BY_TIER,
+            room_label=ROOM_LABEL,
+            tier_order=TIER_ORDER,
+        ),
     )
 
 @app.get("/display", response_class=HTMLResponse)

--- a/templates/launcher.html
+++ b/templates/launcher.html
@@ -36,6 +36,7 @@
   const EVENT_DATES = {{ event_dates|tojson|safe }};
   const ROOMS_BY_TIER = {{ rooms_by_tier|tojson|safe }};
   const ROOM_LABEL = {{ room_label|tojson|safe }};
+  const TIER_ORDER = {{ tier_order|tojson|safe }};
   let chosenDate = EVENT_DATES[0];
 
   const dateRow = document.getElementById('dateButtons');
@@ -57,18 +58,20 @@
   }
 
   function renderTiers(){
-    tierBlocks.innerHTML = Object.entries(ROOMS_BY_TIER).map(([tier,rooms])=>{
+    tierBlocks.innerHTML = TIER_ORDER.map(tier=>{
+      const rooms = ROOMS_BY_TIER[tier] || [];
       const roomBtns = rooms.map(r=>{
         const href = `/display?room=${encodeURIComponent(r)}&date=${encodeURIComponent(chosenDate)}`;
         return `<a class="chip chip-gold" href="${href}">${ROOM_LABEL[r]||r}</a>`;
       }).join('');
+      if(!rooms.length) return '';
       return `
         <div class="panel">
           <div class="panel-title">${tier}</div>
           <div class="panel-body" style="display:flex;flex-wrap:wrap;gap:8px">${roomBtns}</div>
         </div>
       `;
-    }).join('');
+    }).filter(Boolean).join('');
   }
 
   renderDates();


### PR DESCRIPTION
## Summary
- pass the server-side sponsor tier ordering to the launcher template
- render launcher tier panels in the priority order Diamond, Platinum, Gold, General

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68cfd3e3f7f08323813fae38525dcaed