### PR TITLE
Highlight room reservation limits

### DIFF
--- a/templates/rooms.html
+++ b/templates/rooms.html
@@ -39,6 +39,7 @@
     }
     .tier-name{color:var(--muted);font-size:var(--fs-sm)}
     .room-card-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:20px}
+    .highlight{color:#ffd166;font-weight:700}
     .room-card{
       border:1px solid var(--line);
       border-radius:20px;
@@ -107,7 +108,7 @@
   <section class="card room-guide">
     <h1 class="title">Room Guide</h1>
     <ul class="guide-notes">
-      <li><strong>Meeting rooms</strong> are available for reservation up to two times per day, with each session limited to <strong>60 minutes</strong>.</li>
+      <li><strong>Meeting rooms</strong> are available for reservation <span class="highlight">up to two times per day</span>, with each session <span class="highlight">limited to 45 minutes.</span></li>
       <li>Explore the meeting rooms curated for <strong>APEC CEO Summit Korea 2025</strong>. Tap the room to see detailed amenities.</li>
     </ul>
 


### PR DESCRIPTION
## Summary
- update the Room Guide notice to mention the 45-minute session limit
- highlight the daily reservation and session limit phrases in yellow for better visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfd877fdf88323a9ac2f0590a84e0c