### PR TITLE
Update room detail navigation and actions

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -52,7 +52,9 @@ a:hover{text-decoration:underline}
   font-weight:800;
   font-size:var(--fs-lg);
 }
-.nav .link{margin-left:12px;color:#c9d7f2}
+.nav{display:flex;align-items:center}
+.nav .link{margin-left:12px;color:#c9d7f2;display:inline-flex;align-items:center;gap:8px}
+.nav .nav-icon{width:10px;height:10px;border-radius:50%;background:#ffd166;display:inline-block}
 
 .wrap{max-width:1200px;margin:16px auto;padding:0 12px}
 .card{

--- a/templates/room_detail.html
+++ b/templates/room_detail.html
@@ -32,10 +32,14 @@
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>
     <nav class="nav">
-      <a href="/" class="link">Room Guide</a>
-      <a href="/booking" class="link">Booking</a>
-      <a href="/launcher" class="button">Display</a>
-      <a href="/admin" class="button">Admin</a>
+      <a href="/" class="link">
+        <span class="nav-icon" aria-hidden="true"></span>
+        Room Guide
+      </a>
+      <a href="/booking" class="link">
+        <span class="nav-icon" aria-hidden="true"></span>
+        Booking
+      </a>
     </nav>
   </div>
 </header>
@@ -83,7 +87,6 @@
     </div>
     <div style="margin-top:24px;display:flex;flex-wrap:wrap;gap:12px">
       <a class="button" href="/booking">Book this room</a>
-      <a class="button" href="/display?room={{ room_code }}&date={{ schedule_date }}">View live schedule</a>
     </div>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- remove the Display, Admin, and View live schedule actions from the room detail page
- add yellow navigation icons beside the Room Guide and Booking links and align the navigation styling

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfd9cf88f48323ade491e5aaada690