### PR TITLE
Fix room guide navigation on room detail page

### DIFF
--- a/templates/room_detail.html
+++ b/templates/room_detail.html
@@ -34,7 +34,7 @@
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>
     <nav class="nav">
-      <a href="/" class="button">Room Guide</a>
+      <a href="/rooms" class="button">Room Guide</a>
       <a href="/booking" class="button">Booking</a>
     </nav>
   </div>
@@ -42,7 +42,7 @@
 
 <main class="wrap">
   <section class="card">
-    <a href="/" class="muted" style="display:inline-flex;align-items:center;gap:6px;margin-bottom:12px">← Back to rooms</a>
+    <a href="/rooms" class="muted" style="display:inline-flex;align-items:center;gap:6px;margin-bottom:12px">← Back to rooms</a>
     <div class="hero">
       <div class="hero-visual">
         <img src="{{ details.image }}" alt="{{ room_name }}" loading="lazy" />


### PR DESCRIPTION
## Summary
- update the Room Guide button on the room detail view to point to the rooms overview instead of the booking redirect
- ensure the Back to rooms link also returns to the rooms overview

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db6d2a04b0832390f8bcf3d942faa7