### PR TITLE
Add admin controls for disabling meeting room slots

### DIFF
--- a/models.sql
+++ b/models.sql
@@ -29,6 +29,21 @@ CREATE TABLE IF NOT EXISTS bookings (
   INDEX idx_email_date (email, date)
 ) ENGINE=InnoDB;
 
+-- Admin disabled slots
+CREATE TABLE IF NOT EXISTS disabled_slots (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  room_code VARCHAR(64) NOT NULL,
+  date DATE NOT NULL,
+  start_hour TINYINT NOT NULL,
+  end_hour TINYINT NOT NULL,
+  note VARCHAR(255) DEFAULT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_disabled_room FOREIGN KEY (room_code) REFERENCES rooms(code) ON DELETE RESTRICT ON UPDATE CASCADE,
+  INDEX idx_disabled_room_date (room_code, date),
+  INDEX idx_disabled_date (date),
+  CONSTRAINT uq_disabled UNIQUE (room_code, date, start_hour, end_hour)
+) ENGINE=InnoDB;
+
 -- Companies (신규)
 CREATE TABLE IF NOT EXISTS companies (
   id INT PRIMARY KEY AUTO_INCREMENT,

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -115,6 +115,93 @@
   </section>
 
   <section class="card">
+    <h2 class="title">Manage Disabled Slots</h2>
+
+    {% if disable_error %}
+      <div class="alert error">{{ disable_error }}</div>
+    {% elif disable_msg %}
+      <div class="alert success">{{ disable_msg }}</div>
+    {% endif %}
+
+    <form class="toolbar" method="post" action="/admin/disabled/add">
+      <label class="field">
+        <span>Date</span>
+        <select name="date" required>
+          {% for d in event_dates %}
+            <option value="{{ d }}" {% if d == date %}selected{% endif %}>{{ d }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="field">
+        <span>Room</span>
+        <select name="room" required>
+          {% for code, label in room_label.items() %}
+            <option value="{{ code }}" {% if room == code %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="field">
+        <span>Start</span>
+        <select name="start_hour" required>
+          {% for h in hours %}
+            <option value="{{ h }}">{{ "%02d:00" % h }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="field">
+        <span>Blocks</span>
+        <select name="blocks" required>
+          {% for b in range(1, max_blocks + 1) %}
+            <option value="{{ b }}">{{ b }} ({{ b * 60 }} min)</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="field" style="flex:1">
+        <span>Note (optional)</span>
+        <input type="text" name="note" placeholder="Reason or memo" />
+      </label>
+      <button type="submit" class="button" style="align-self:flex-end">Disable Slot</button>
+    </form>
+
+    <div class="table-scroll">
+      <table class="table">
+        <thead>
+          <tr>
+            <th style="width:80px">ID</th>
+            <th style="width:120px">Date</th>
+            <th style="width:160px">Room</th>
+            <th style="width:160px">Time</th>
+            <th>Note</th>
+            <th style="width:110px">Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for slot in disabled_items %}
+          <tr>
+            <td>{{ slot.id }}</td>
+            <td>{{ slot.date }}</td>
+            <td>{{ room_label[slot.room_code] if slot.room_code in room_label else slot.room_code }}</td>
+            <td>{{ "%02d:00" % slot.start_hour }} – {{ "%02d:00" % slot.end_hour }}</td>
+            <td>{{ slot.note or '' }}</td>
+            <td>
+              <form method="post" action="/admin/disabled/delete" onsubmit="return confirm('Remove disabled slot #{{ slot.id }}?');">
+                <input type="hidden" name="disabled_id" value="{{ slot.id }}" />
+                <input type="hidden" name="date" value="{{ date }}" />
+                {% if room %}<input type="hidden" name="room" value="{{ room }}" />{% endif %}
+                <button type="submit" class="danger">Delete</button>
+              </form>
+            </td>
+          </tr>
+          {% endfor %}
+          {% if not disabled_items %}
+          <tr><td colspan="6" class="muted" style="text-align:center">No disabled slots for selection.</td></tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="card">
     <h2 class="title">Manage Companies</h2>
 
     {% if company_error %}

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -238,19 +238,40 @@
   }
 
   // 보드
-  function renderBoard(date, room, items, blocks){
+  function renderBoard(date, room, data, blocks){
     $('#boardLabel').textContent = `${ROOM_LABEL[room]||room} · ${date} · Blocks ${blocks}`;
     const busyAt = {};
-    (items||[]).forEach(it => { for(let h=it.start_hour; h<it.end_hour; h++) busyAt[h] = {company:it.company,tier:it.tier}; });
+    const items = data.items || [];
+    const disabled = data.disabled || [];
+    items.forEach(it => {
+      for(let h=it.start_hour; h<it.end_hour; h++){
+        busyAt[h] = { type:'booking', company:it.company, tier:it.tier };
+      }
+    });
+    disabled.forEach(slot => {
+      for(let h=slot.start_hour; h<slot.end_hour; h++){
+        busyAt[h] = { type:'disabled', note: slot.note || '' };
+      }
+    });
     let html = '<table class="table"><thead><tr><th style="width:160px">Time</th><th>Status</th><th>Company</th></tr></thead><tbody>';
     for(const h of HOURS){
-      const busy = !!busyAt[h];
-      const status = busy ? '<b class="no">Booked</b>' : '<b class="ok">Available</b>';
-      const company = busy ? `${busyAt[h].company} (${busyAt[h].tier})` : '';
+      const entry = busyAt[h];
+      const busy = !!entry;
+      let status;
+      let info = '';
+      if (entry && entry.type === 'disabled'){
+        status = '<b class="no">Unavailable</b>';
+        info = entry.note || 'Blocked by admin';
+      } else if (entry){
+        status = '<b class="no">Booked</b>';
+        info = `${entry.company} (${entry.tier})`;
+      } else {
+        status = '<b class="ok">Available</b>';
+      }
       html += `<tr data-h="${h}" class="${busy ? '' : 'slot-avail'}">
         <td>${fmt(h)} – ${fmt(h+1)}</td>
         <td>${status}</td>
-        <td>${company}</td>
+        <td>${info}</td>
       </tr>`;
     }
     html += '</tbody></table>';
@@ -281,7 +302,7 @@
     if(!date || !room) return;
     const data = await apiAvailability(date, room);
     await refreshStart();
-    renderBoard(date, room, data.items||[], blocks);
+    renderBoard(date, room, data, blocks);
   }
 
   // 하루 2시간 제한 사전 안내/차단


### PR DESCRIPTION
## Summary
- add a new `disabled_slots` table and backend helpers to manage admin-blocked room periods
- extend the admin dashboard to create and delete disabled slots with optional notes
- surface disabled periods in booking availability so users cannot reserve blocked times

## Testing
- python -m compileall app.py templates/booking.html templates/admin.html

------
https://chatgpt.com/codex/tasks/task_e_68e0c45fc858832395ff2ccbc0d53aac