### PR TITLE
Add script for resetting disabled slots table

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -80,3 +80,11 @@ WantedBy=timers.target
 sudo systemctl daemon-reload
 sudo systemctl enable --now apec-booking
 sudo systemctl enable --now apec-digest.timer
+
+
+예약 차단 테이블 초기화 방법
+---------------------------
+1) `/opt/apec-booking/.env` 또는 `ENV_FILE` 환경 변수로 지정한 경로에 데이터베이스 접속 정보가 올바르게 설정되어 있는지 확인합니다.
+2) 프로젝트 루트에서 `./reset_disabled_slots.sh`를 실행합니다.
+   - 이 스크립트는 `disabled_slots` 테이블을 **DROP** 한 뒤 동일한 스키마로 다시 생성합니다.
+   - 실행 시 테이블에 저장돼 있던 예약 차단 데이터가 모두 삭제되니 주의하세요.

--- a/reset_disabled_slots.sh
+++ b/reset_disabled_slots.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ------------------------------------------------------------
+# APEC Booking - Reset `disabled_slots` table
+# ------------------------------------------------------------
+
+ENV_FILE="${ENV_FILE:-/opt/apec-booking/.env}"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "[-] .env not found at: $ENV_FILE"
+  echo "    Set ENV_FILE=/path/to/.env or place it at /opt/apec-booking/.env"
+  exit 1
+fi
+
+# read_env VAR_NAME [default]
+read_env() {
+  local key="$1"; local def="${2:-}"
+  local line
+  line="$(grep -E "^[[:space:]]*${key}[[:space:]]*=" "$ENV_FILE" | tail -n1 || true)"
+  if [[ -z "$line" ]]; then
+    printf '%s' "$def"
+    return 0
+  fi
+  line="${line%%$'\r'}"
+  line="${line#*=}"
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  if [[ ( "$line" == \"*\" && "$line" == *\" ) || ( "$line" == \'*\' && "$line" == *\' ) ]]; then
+    line="${line:1:${#line}-2}"
+  fi
+  line="${line%%$'\r'}"
+  printf '%s' "$line"
+}
+
+MYSQL_HOST="$(read_env MYSQL_HOST 127.0.0.1)"
+MYSQL_PORT="$(read_env MYSQL_PORT 3306)"
+MYSQL_DB="$(read_env MYSQL_DB apec_booking)"
+MYSQL_USER="$(read_env MYSQL_USER apec)"
+MYSQL_PASSWORD="$(read_env MYSQL_PASSWORD "")"
+
+if [[ -z "$MYSQL_PASSWORD" ]]; then
+  echo "[-] MYSQL_PASSWORD is empty (check $ENV_FILE: MYSQL_PASSWORD=...)"
+  exit 1
+fi
+
+if ! command -v mysql >/dev/null 2>&1; then
+  echo "[-] mysql client not found. Install it first (e.g., 'sudo dnf install -y mysql' or 'sudo apt-get install -y mysql-client')."
+  exit 1
+fi
+
+export MYSQL_PWD="$MYSQL_PASSWORD"
+
+echo "[*] Resetting disabled_slots table in database '$MYSQL_DB'..."
+
+mysql --protocol=TCP -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" "$MYSQL_DB" <<'SQL'
+DROP TABLE IF EXISTS disabled_slots;
+CREATE TABLE disabled_slots (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  room_code VARCHAR(64) NOT NULL,
+  date DATE NOT NULL,
+  start_hour TINYINT NOT NULL,
+  end_hour TINYINT NOT NULL,
+  note VARCHAR(255) DEFAULT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_disabled_room FOREIGN KEY (room_code) REFERENCES rooms(code) ON DELETE RESTRICT ON UPDATE CASCADE,
+  INDEX idx_disabled_room_date (room_code, date),
+  INDEX idx_disabled_date (date),
+  CONSTRAINT uq_disabled UNIQUE (room_code, date, start_hour, end_hour)
+) ENGINE=InnoDB;
+SQL
+
+echo "[✓] disabled_slots table has been reset."


### PR DESCRIPTION
## Summary
- add a reset_disabled_slots.sh utility that drops and recreates the disabled_slots table using .env credentials
- document how to run the reset script and warn that existing disabled slot data will be deleted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c7834ce0832392c27630a33a0a7c