### PR TITLE
Allow all companies to book any meeting room

### DIFF
--- a/templates/booking.html
+++ b/templates/booking.html
@@ -26,7 +26,6 @@
     }
     #dateField input[type="date"]{ padding-left:62px }
     .hidden{display:none}
-    .locked { pointer-events:none; background:#222; color:#aaa; }
   </style>
 </head>
 <body>
@@ -127,13 +126,12 @@
 </main>
 
 <script>
-  const EVENT_DATES   = {{ event_dates|tojson|safe }};
-  const ROOMS_BY_TIER = {{ rooms_by_tier|tojson|safe }};
-  const ROOM_LABEL    = {{ room_label|tojson|safe }};
-  const HOURS         = {{ hours|tojson|safe }};
-  const MAX_BLOCKS    = {{ max_blocks|tojson|safe }};
-  const INITIAL_DATE  = {{ initial_date|tojson|safe }};
-  const OTHER_ROOM    = {{ OTHER_ROOM_CODE|tojson|safe }};
+  const EVENT_DATES    = {{ event_dates|tojson|safe }};
+  const ALL_ROOMS      = {{ all_room_codes|tojson|safe }};
+  const ROOM_LABEL     = {{ room_label|tojson|safe }};
+  const HOURS          = {{ hours|tojson|safe }};
+  const MAX_BLOCKS     = {{ max_blocks|tojson|safe }};
+  const INITIAL_DATE   = {{ initial_date|tojson|safe }};
 
   const $ = (s, r=document) => r.querySelector(s);
   const fmt = h => String(h).padStart(2,'0') + ':00';
@@ -175,27 +173,38 @@
   }
   function isOtherSelected(){ return $('#company').value === 'Other'; }
 
+  function populateRooms(codes){
+    const sel = $('#room');
+    const previous = sel.value;
+    sel.innerHTML = codes.map(code => `<option value="${code}">${ROOM_LABEL[code]||code}</option>`).join('');
+    if(previous && codes.includes(previous)){
+      sel.value = previous;
+    } else if(codes.length){
+      sel.value = codes[0];
+    }
+  }
+
   function enterOtherMode(){
     $('#companyOtherField').classList.remove('hidden');
-    $('#tierView').value = 'General';
-    $('#tier').value = 'General';
-    $('#room').innerHTML = `<option value="${OTHER_ROOM}">${ROOM_LABEL[OTHER_ROOM]||OTHER_ROOM}</option>`;
-    $('#room').classList.add('locked');
+    $('#tierView').value = 'Other';
+    $('#tier').value = 'Other';
+    populateRooms(ALL_ROOMS);
   }
   function exitOtherMode(){
     $('#companyOtherField').classList.add('hidden');
-    $('#room').classList.remove('locked');
   }
 
   function applyTierFromCompany(){
-    if(isOtherSelected()){ enterOtherMode(); return; }
+    if(isOtherSelected()){
+      enterOtherMode();
+      return;
+    }
     exitOtherMode();
     const opt = $('#company option:checked');
     const tier = opt?.dataset?.tier || '';
     $('#tierView').value = tier || '(Unknown)';
     $('#tier').value = tier || '';
-    const rooms = ROOMS_BY_TIER[tier] || [];
-    $('#room').innerHTML = rooms.map(code => `<option value="${code}">${ROOM_LABEL[code]||code}</option>`).join('');
+    populateRooms(ALL_ROOMS);
   }
 
   // 시작 옵션

--- a/templates/launcher.html
+++ b/templates/launcher.html
@@ -29,20 +29,19 @@
     <!-- 날짜 선택 버튼 -->
     <div class="row" id="dateButtons" style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:20px"></div>
 
-    <!-- 티어별 룸 버튼 -->
-    <div id="tierBlocks" style="display:grid;gap:20px"></div>
+    <!-- 룸 버튼 -->
+    <div id="roomBlocks" style="display:grid;gap:20px"></div>
   </section>
 </main>
 
 <script>
   const EVENT_DATES = {{ event_dates|tojson|safe }};
-  const ROOMS_BY_TIER = {{ rooms_by_tier|tojson|safe }};
-  const ROOM_LABEL = {{ room_label|tojson|safe }};
-  const TIER_ORDER = {{ tier_order|tojson|safe }};
+  const ALL_ROOMS   = {{ all_room_codes|tojson|safe }};
+  const ROOM_LABEL  = {{ room_label|tojson|safe }};
   let chosenDate = EVENT_DATES[0];
 
   const dateRow = document.getElementById('dateButtons');
-  const tierBlocks = document.getElementById('tierBlocks');
+  const roomBlocks = document.getElementById('roomBlocks');
 
   function renderDates(){
     dateRow.innerHTML = EVENT_DATES.map(d => `
@@ -51,7 +50,7 @@
     dateRow.querySelectorAll('button').forEach(btn=>{
       btn.addEventListener('click', ()=>{
         chosenDate = btn.dataset.date;
-        renderTiers();
+        renderRooms();
         dateRow.querySelectorAll('button').forEach(x=>x.classList.remove('chip-active'));
         btn.classList.add('chip-active');
       });
@@ -59,25 +58,21 @@
     dateRow.querySelector(`button[data-date="${chosenDate}"]`).classList.add('chip-active');
   }
 
-  function renderTiers(){
-    tierBlocks.innerHTML = TIER_ORDER.map(tier=>{
-      const rooms = ROOMS_BY_TIER[tier] || [];
-      const roomBtns = rooms.map(r=>{
-        const href = `/display?room=${encodeURIComponent(r)}&date=${encodeURIComponent(chosenDate)}`;
-        return `<a class="chip chip-gold" href="${href}">${ROOM_LABEL[r]||r}</a>`;
-      }).join('');
-      if(!rooms.length) return '';
-      return `
-        <div class="panel">
-          <div class="panel-title">${tier}</div>
-          <div class="panel-body" style="display:flex;flex-wrap:wrap;gap:8px">${roomBtns}</div>
-        </div>
-      `;
-    }).filter(Boolean).join('');
+  function renderRooms(){
+    const roomBtns = ALL_ROOMS.map(r=>{
+      const href = `/display?room=${encodeURIComponent(r)}&date=${encodeURIComponent(chosenDate)}`;
+      return `<a class="chip chip-gold" href="${href}">${ROOM_LABEL[r]||r}</a>`;
+    }).join('');
+    roomBlocks.innerHTML = `
+      <div class="panel">
+        <div class="panel-title">All rooms</div>
+        <div class="panel-body" style="display:flex;flex-wrap:wrap;gap:8px">${roomBtns}</div>
+      </div>
+    `;
   }
 
   renderDates();
-  renderTiers();
+  renderRooms();
 </script>
 </body>
 </html>

--- a/templates/room_detail.html
+++ b/templates/room_detail.html
@@ -13,7 +13,6 @@
     .hero-code{position:absolute;top:18px;right:18px;padding:6px 14px;border-radius:999px;border:1px solid rgba(255,255,255,0.18);background:rgba(9,17,32,0.85);font-weight:700;letter-spacing:0.08em}
     .hero-category{position:absolute;bottom:18px;left:18px;padding:6px 14px;border-radius:10px;border:1px solid rgba(255,255,255,0.14);background:rgba(9,17,32,0.75);font-size:var(--fs-xs,13px);letter-spacing:0.08em;text-transform:uppercase;color:#dbe6ff}
     .hero-details{display:flex;flex-direction:column;gap:14px}
-    .badge-tier{display:inline-flex;align-items:center;gap:8px;padding:8px 16px;border-radius:999px;border:1px solid rgba(255,255,255,0.18);background:rgba(9,17,32,0.8);font-size:var(--fs-sm);font-weight:700;letter-spacing:0.08em;text-transform:uppercase}
     .hero-meta{display:grid;gap:10px;margin:0}
     .hero-meta div{display:flex;justify-content:space-between;gap:12px;font-size:var(--fs-sm);color:#dbe6ff}
     .hero-meta dt{opacity:0.65}
@@ -50,7 +49,6 @@
         <span class="hero-category">{{ details.category }}</span>
       </div>
       <div class="hero-details">
-        <div class="badge-tier">{{ tier_label }}</div>
         <h1 class="title" style="margin:0">{{ room_name }}</h1>
         <dl class="hero-meta">
           <div><dt>Location</dt><dd>{{ details.location }}</dd></div>

--- a/templates/rooms.html
+++ b/templates/rooms.html
@@ -22,23 +22,7 @@
       color:#d5e3ff;
       font-size:var(--fs-sm);
     }
-    .tier-group{margin-top:28px;display:flex;flex-direction:column;gap:16px}
-    .tier-header{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap}
-    .badge-tier{
-      display:inline-flex;
-      align-items:center;
-      gap:8px;
-      padding:8px 14px;
-      border-radius:999px;
-      border:1px solid rgba(255,255,255,0.18);
-      background:rgba(9,17,32,0.7);
-      font-size:var(--fs-sm);
-      font-weight:700;
-      letter-spacing:0.08em;
-      text-transform:uppercase;
-    }
-    .tier-name{color:var(--muted);font-size:var(--fs-sm)}
-    .room-card-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:20px}
+    .room-card-grid{margin-top:28px;display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:20px}
     .highlight{color:#ffd166;font-weight:700}
     .room-card{
       border:1px solid var(--line);
@@ -112,40 +96,33 @@
     <ul class="guide-notes">
       <li><strong>Meeting rooms</strong> are available for reservation <span class="highlight">up to two times per day</span>, with each session <span class="highlight">limited to 45 minutes.</span></li>
       <li>Explore the meeting rooms curated for <strong>APEC CEO Summit Korea 2025</strong>. Tap the room to see detailed amenities.</li>
+      <li>All registered companies — including <strong>Other</strong> entries — can reserve <strong>any meeting room</strong>.</li>
     </ul>
 
-    {% for section in sections %}
-    <div class="tier-group">
-      <div class="tier-header">
-        <div class="badge-tier">{{ section.tier_label }}</div>
-        <span class="tier-name">{{ section.tier }}</span>
-      </div>
-      <div class="room-card-grid">
-        {% for room in section.rooms %}
-        <article class="room-card">
-          <div class="room-card-image">
-            <img src="{{ room.image }}" alt="{{ room.name }}" loading="lazy" />
-            <span class="room-category">{{ room.category }}</span>
-          </div>
-          <h3 class="room-name">{{ room.name }}</h3>
-          <dl class="room-meta">
-            <div><dt>Location</dt><dd>{{ room.location }}</dd></div>
-            <div><dt>Capacity</dt><dd>{{ room.capacity }} pax</dd></div>
-            <div><dt>Meeting Room Code</dt><dd>{{ room.meeting_code }}</dd></div>
-          </dl>
-          <div class="room-features">
-            {% for feature in room.features %}
-            <span class="chip-small">{{ feature }}</span>
-            {% endfor %}
-          </div>
-          <div class="room-card-footer">
-            <a class="button" href="/rooms/{{ room.code }}">View details</a>
-          </div>
-        </article>
-        {% endfor %}
-      </div>
+    <div class="room-card-grid">
+      {% for room in rooms %}
+      <article class="room-card">
+        <div class="room-card-image">
+          <img src="{{ room.image }}" alt="{{ room.name }}" loading="lazy" />
+          <span class="room-category">{{ room.category }}</span>
+        </div>
+        <h3 class="room-name">{{ room.name }}</h3>
+        <dl class="room-meta">
+          <div><dt>Location</dt><dd>{{ room.location }}</dd></div>
+          <div><dt>Capacity</dt><dd>{{ room.capacity }} pax</dd></div>
+          <div><dt>Meeting Room Code</dt><dd>{{ room.meeting_code }}</dd></div>
+        </dl>
+        <div class="room-features">
+          {% for feature in room.features %}
+          <span class="chip-small">{{ feature }}</span>
+          {% endfor %}
+        </div>
+        <div class="room-card-footer">
+          <a class="button" href="/rooms/{{ room.code }}">View details</a>
+        </div>
+      </article>
+      {% endfor %}
     </div>
-    {% endfor %}
   </section>
 </main>
 </body>


### PR DESCRIPTION
## Summary
- remove tier-based room restrictions so every company, including Other, can reserve any meeting room
- update the booking and launcher interfaces to present the complete room list regardless of tier selection
- refresh the room guide and detail pages to drop tier badges and note that all rooms are open to every company

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d85e79908323b9a50f503e27a95f