### PR TITLE
Ensure company seed widens tier enum

### DIFF
--- a/alter_tier_other.sh
+++ b/alter_tier_other.sh
@@ -35,7 +35,11 @@ echo "Step 1) Expand ENUM to include both General and Other (safe widen)"
 echo "--------------"
 mysql --protocol=TCP -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" "$MYSQL_DB" <<'SQL'
 ALTER TABLE bookings
-  MODIFY COLUMN tier ENUM('Diamond','Platinum','Gold','General','Other') NOT NULL;
+  MODIFY COLUMN tier ENUM(
+    'Diamond','Platinum','Gold','Legal Partner','Knowledge Partner',
+    'Media Partner - Premier','Media Partner - Platinum','Media Partner - Gold',
+    'General','Other'
+  ) NOT NULL;
 SQL
 
 echo "--------------"
@@ -49,7 +53,11 @@ echo "Step 3) Shrink ENUM to remove General"
 echo "--------------"
 mysql --protocol=TCP -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" "$MYSQL_DB" <<'SQL'
 ALTER TABLE bookings
-  MODIFY COLUMN tier ENUM('Diamond','Platinum','Gold','Other') NOT NULL;
+  MODIFY COLUMN tier ENUM(
+    'Diamond','Platinum','Gold','Legal Partner','Knowledge Partner',
+    'Media Partner - Premier','Media Partner - Platinum','Media Partner - Gold',
+    'Other'
+  ) NOT NULL;
 SQL
 
 echo "--------------"

--- a/app.py
+++ b/app.py
@@ -32,16 +32,21 @@ MAX_BLOCKS = 2              # 1h/block, 최대 2블록 = 2시간
 
 # 룸/티어 정의
 ROOM_TIER_LABELS = {
-    "Diamond": "Diamond Sponsor Only",
-    "Platinum": "Platinum Sponsor Only",
-    "Gold": "Gold Sponsor Only",
-    "General": "General Only",
+    "Diamond": "Diamond Sponsor",
+    "Platinum": "Platinum Sponsor",
+    "Gold": "Gold Sponsor",
+    "Legal Partner": "Legal Partner",
+    "Knowledge Partner": "Knowledge Partner",
+    "Media Partner - Premier": "Media Partner - Premier",
+    "Media Partner - Platinum": "Media Partner - Platinum",
+    "Media Partner - Gold": "Media Partner - Gold",
+    "Other": "Other",
 }
 
 TIER_ORDER = list(ROOM_TIER_LABELS)
 TIER_INDEX = {tier: idx for idx, tier in enumerate(TIER_ORDER)}
 
-COMPANY_MANAGED_TIERS = [tier for tier in TIER_ORDER if tier != "General"]
+COMPANY_MANAGED_TIERS = [tier for tier in TIER_ORDER if tier != "Other"]
 
 ROOMS_DATA = [
     {
@@ -86,9 +91,9 @@ ROOMS_DATA = [
     {
         "code": "DM4",
         "tier": "Diamond",
-        "name": "Outdoor F&B Zone, Office Bus",
-        "category": "Outdoor F&B Zone, Office Bus",
-        "location": "F&B Zone",
+        "name": "Meeting Room 4",
+        "category": "Indoor Meeting Suite",
+        "location": "1F",
         "capacity": 7,
         "meeting_code": "DM4",
         "summary": "",
@@ -99,7 +104,7 @@ ROOMS_DATA = [
     {
         "code": "PM1",
         "tier": "Platinum",
-        "name": "Meeting Room 1",
+        "name": "Meeting Room 5",
         "category": "Indoor Meeting Suite",
         "location": "1F",
         "capacity": 8,
@@ -112,7 +117,7 @@ ROOMS_DATA = [
     {
         "code": "PM2",
         "tier": "Platinum",
-        "name": "Meeting Room 2",
+        "name": "Meeting Room 6",
         "category": "Indoor Meeting Suite",
         "location": "B1",
         "capacity": 8,
@@ -125,7 +130,7 @@ ROOMS_DATA = [
     {
         "code": "PM3",
         "tier": "Platinum",
-        "name": "Meeting Room 3",
+        "name": "Meeting Room 7",
         "category": "Indoor Meeting Suite",
         "location": "B1",
         "capacity": 6,
@@ -138,9 +143,9 @@ ROOMS_DATA = [
     {
         "code": "PM4",
         "tier": "Platinum",
-        "name": "Outdoor F&B Zone, Office Bus",
-        "category": "Outdoor F&B Zone, Office Bus",
-        "location": "F&B Zone",
+        "name": "Meeting Room 8",
+        "category": "Indoor Meeting Suite",
+        "location": "B1",
         "capacity": 7,
         "meeting_code": "PM4",
         "summary": "",
@@ -151,7 +156,7 @@ ROOMS_DATA = [
     {
         "code": "GM1",
         "tier": "Gold",
-        "name": "Meeting Room 1",
+        "name": "Meeting Room 9",
         "category": "Indoor Meeting Suite",
         "location": "B1",
         "capacity": 6,
@@ -163,10 +168,10 @@ ROOMS_DATA = [
     },
     {
         "code": "GM2",
-        "tier": "Gold",
-        "name": "Meeting Room 2",
-        "category": "Indoor Meeting Suite",
-        "location": "B1",
+        "tier": "Other",
+        "name": "Outdoor Meeting Room 1 (Hyundai Office Bus)",
+        "category": "Outdoor Meeting Suite",
+        "location": "F&B Zone",
         "capacity": 6,
         "meeting_code": "GM2",
         "summary": "",
@@ -176,10 +181,10 @@ ROOMS_DATA = [
     },
     {
         "code": "GM3",
-        "tier": "Gold",
-        "name": "OUTDOOR F&B ZONE_OFFICE BUS",
-        "category": "OUTDOOR F&B ZONE_OFFICE BUS",
-        "location": "F&B ZONE",
+        "tier": "Other",
+        "name": "Outdoor Meeting Room 2 (Hyundai Office Bus)",
+        "category": "Outdoor Meeting Suite",
+        "location": "F&B Zone",
         "capacity": 7,
         "meeting_code": "GM3",
         "summary": "",
@@ -189,10 +194,10 @@ ROOMS_DATA = [
     },
     {
         "code": "NM1",
-        "tier": "General",
-        "name": "OUTDOOR F&B ZONE_OFFICE BUS",
-        "category": "OUTDOOR F&B ZONE_OFFICE BUS",
-        "location": "MAIN ENTERANCE",
+        "tier": "Other",
+        "name": "Media Interview Room",
+        "category": "Media Suite",
+        "location": "Main Entrance",
         "capacity": 7,
         "meeting_code": "NM1",
         "summary": "",
@@ -213,10 +218,21 @@ ROOMS_SORTED = sorted(
     key=lambda r: (TIER_INDEX[r["tier"]], r["order"], r["code"]),
 )
 ALL_ROOM_CODES = [room["code"] for room in ROOMS_SORTED]
-ROOMS_BY_TIER: dict[str, list[str]] = {}
-for tier in ROOM_TIER_LABELS:
-    ROOMS_BY_TIER[tier] = list(ALL_ROOM_CODES)
-ROOMS_BY_TIER["Other"] = list(ALL_ROOM_CODES)
+MEETING_ROOMS = ["DM1", "DM2", "DM3", "DM4", "PM1", "PM2", "PM3", "PM4", "GM1"]
+OUTDOOR_ROOMS = ["GM2", "GM3"]
+MEDIA_ROOMS = ["GM2", "GM3", "NM1"]
+
+ROOMS_BY_TIER: dict[str, list[str]] = {
+    "Diamond": list(MEETING_ROOMS),
+    "Platinum": list(MEETING_ROOMS),
+    "Gold": list(MEETING_ROOMS),
+    "Legal Partner": list(MEETING_ROOMS),
+    "Knowledge Partner": list(MEETING_ROOMS),
+    "Media Partner - Premier": list(MEDIA_ROOMS),
+    "Media Partner - Platinum": list(MEDIA_ROOMS),
+    "Media Partner - Gold": list(MEDIA_ROOMS),
+    "Other": list(OUTDOOR_ROOMS),
+}
 
 app = FastAPI(title="APEC Meeting Rooms Booking")
 app.mount("/static", StaticFiles(directory="static"), name="static")
@@ -514,6 +530,7 @@ def booking_page(request: Request):
             event_dates=EVENT_DATES,
             all_room_codes=ALL_ROOM_CODES,
             room_label=ROOM_LABEL,
+            rooms_by_tier=ROOMS_BY_TIER,
             hours=HOURS,
             initial_date=initial_date,
             max_blocks=MAX_BLOCKS,
@@ -659,7 +676,7 @@ def create_booking(
         real_company = (company_other or "").strip()
         if not real_company:
             raise HTTPException(status_code=400, detail="Company name required for Other")
-        tier = "General"
+        tier = "Other"
         company_to_save = real_company
     else:
         db_tier = get_company_tier(company)
@@ -667,6 +684,10 @@ def create_booking(
             raise HTTPException(status_code=400, detail="Unknown company")
         tier = db_tier
         company_to_save = company.strip()
+
+    allowed_rooms = ROOMS_BY_TIER.get(tier, [])
+    if allowed_rooms and room not in allowed_rooms:
+        raise HTTPException(status_code=403, detail="Selected room not available for this tier")
 
     # --- 시간/블록 검증 ---
     blocks = max(1, min(MAX_BLOCKS, int(blocks)))

--- a/create_companies.sh
+++ b/create_companies.sh
@@ -76,39 +76,84 @@ USE apec_booking;
 CREATE TABLE IF NOT EXISTS companies (
   id INT PRIMARY KEY AUTO_INCREMENT,
   name VARCHAR(200) NOT NULL UNIQUE,
-  tier ENUM('Diamond','Platinum','Gold') NOT NULL,
+  tier ENUM(
+    'Diamond','Platinum','Gold','Legal Partner','Knowledge Partner',
+    'Media Partner - Premier','Media Partner - Platinum','Media Partner - Gold'
+  ) NOT NULL,
   INDEX idx_tier_name (tier, name)
 ) ENGINE=InnoDB;
 
--- Seed companies (idempotent)
-INSERT IGNORE INTO companies(name, tier) VALUES
+-- Ensure legacy ENUM definitions are widened before seeding.
+ALTER TABLE companies
+  MODIFY COLUMN tier ENUM(
+    'Diamond','Platinum','Gold','Legal Partner','Knowledge Partner',
+    'Media Partner - Premier','Media Partner - Platinum','Media Partner - Gold'
+  ) NOT NULL;
+
+-- Reset and seed companies
+DELETE FROM companies;
+ALTER TABLE companies AUTO_INCREMENT = 1;
+
+INSERT INTO companies(name, tier) VALUES
 -- Diamond
-('MEBO','Diamond'),
-('UPbit','Diamond'),
-('Korea Hydro & Nuclear Power Co., Ltd. (KHNP)','Diamond'),
-('SK hynix Inc.','Diamond'),
 ('Samsung','Diamond'),
-('Posco Holdings','Diamond'),
-('Hyundai Motor Group','Diamond'),
+('SK','Diamond'),
+('Hyundai','Diamond'),
+('LG','Diamond'),
+('Lotte','Diamond'),
+('Posco International','Diamond'),
 ('Hanwha','Diamond'),
+('HD Hyundai','Diamond'),
 ('GS','Diamond'),
+('Shinsegae Group','Diamond'),
+('Korea Hydro & Nuclear Power','Diamond'),
+('UPbit','Diamond'),
+('Hybe','Diamond'),
+('Mebo','Diamond'),
 
 -- Platinum
-('KB Kookmin Bank','Platinum'),
-('MegazoneCloud','Platinum'),
-('Woori Bank','Platinum'),
-('LS Corp.','Platinum'),
-('Wuliangye','Platinum'),
-('Citi','Platinum'),
-('Johnson & Johnson','Platinum'),
+('Korean Air Lines','Platinum'),
+('LS','Platinum'),
 ('Doosan','Platinum'),
+('KT','Platinum'),
+('Naver','Platinum'),
 ('Shinhan Bank','Platinum'),
-('NAVER Corporation','Platinum'),
-('TikTok','Platinum'),
+('Kookmin Bank','Platinum'),
+('Woori Bank','Platinum'),
+('Hana Bank','Platinum'),
+('CJ','Platinum'),
+('Korea zinc','Platinum'),
+('Megazone Cloud','Platinum'),
+('Kolon','Platinum'),
+('HS Hyosung','Platinum'),
+('Citi','Platinum'),
+('Meta','Platinum'),
+('AWS','Platinum'),
+('Johnsons&Johnson','Platinum'),
+('Coupang','Platinum'),
+('TicTok','Platinum'),
+('Wuliangye','Platinum'),
 
 -- Gold
+('AB InBev','Gold'),
+('Ananti','Gold'),
 ('Microsoft','Gold'),
-('Google Korea','Gold');
+('Google','Gold'),
+('LONGi','Gold'),
+('Vobile','Gold'),
+
+-- Partners
+('Kim & Chang','Legal Partner'),
+('Deloitte','Knowledge Partner'),
+('Bloomberg','Media Partner - Premier'),
+('Caixin','Media Partner - Premier'),
+('CGTN','Media Partner - Premier'),
+('CNBC','Media Partner - Premier'),
+('Economist Imapct','Media Partner - Platinum'),
+('Financial Times','Media Partner - Gold'),
+('Foreign Affairs','Media Partner - Gold'),
+('Time','Media Partner - Gold'),
+('The Wall Street Journal','Media Partner - Gold');
 SQL
 
 echo "[✓] companies table ensured and seed data inserted."

--- a/models.sql
+++ b/models.sql
@@ -7,8 +7,8 @@ USE apec_booking;
 CREATE TABLE IF NOT EXISTS rooms (
   id INT PRIMARY KEY AUTO_INCREMENT,
   code VARCHAR(64) NOT NULL UNIQUE,
-  label VARCHAR(100) NOT NULL,
-  tier ENUM('Diamond','Platinum','Gold','General') NOT NULL
+  label VARCHAR(120) NOT NULL,
+  tier ENUM('Diamond','Platinum','Gold','Other') NOT NULL
 ) ENGINE=InnoDB;
 
 -- Bookings
@@ -16,7 +16,10 @@ CREATE TABLE IF NOT EXISTS bookings (
   id BIGINT PRIMARY KEY AUTO_INCREMENT,
   company VARCHAR(200) NOT NULL,
   email VARCHAR(190) NOT NULL,
-  tier ENUM('Diamond','Platinum','Gold','General') NOT NULL,
+  tier ENUM(
+    'Diamond','Platinum','Gold','Legal Partner','Knowledge Partner',
+    'Media Partner - Premier','Media Partner - Platinum','Media Partner - Gold','Other'
+  ) NOT NULL,
   room_code VARCHAR(64) NOT NULL,
   date DATE NOT NULL,
   start_hour TINYINT NOT NULL,
@@ -48,7 +51,10 @@ CREATE TABLE IF NOT EXISTS disabled_slots (
 CREATE TABLE IF NOT EXISTS companies (
   id INT PRIMARY KEY AUTO_INCREMENT,
   name VARCHAR(200) NOT NULL UNIQUE,
-  tier ENUM('Diamond','Platinum','Gold') NOT NULL,
+  tier ENUM(
+    'Diamond','Platinum','Gold','Legal Partner','Knowledge Partner',
+    'Media Partner - Premier','Media Partner - Platinum','Media Partner - Gold'
+  ) NOT NULL,
   INDEX idx_tier_name (tier, name)
 ) ENGINE=InnoDB;
 
@@ -57,43 +63,75 @@ INSERT IGNORE INTO rooms(code,label,tier) VALUES
 ('DM1','DM1 · Meeting Room 1','Diamond'),
 ('DM2','DM2 · Meeting Room 2','Diamond'),
 ('DM3','DM3 · Meeting Room 3','Diamond'),
-('DM4','DM4 · Outdoor F&B Zone, Office Bus','Diamond'),
-('PM1','PM1 · Meeting Room 1','Platinum'),
-('PM2','PM2 · Meeting Room 2','Platinum'),
-('PM3','PM3 · Meeting Room 3','Platinum'),
-('PM4','PM4 · Outdoor F&B Zone, Office Bus','Platinum'),
-('GM1','GM1 · Meeting Room 1','Gold'),
-('GM2','GM2 · Meeting Room 2','Gold'),
-('GM3','GM3 · Meeting Room 3','Gold'),
-('NM1','NM1 · MAIN ENTERANCE','General');
+('DM4','DM4 · Meeting Room 4','Diamond'),
+('PM1','PM1 · Meeting Room 5','Platinum'),
+('PM2','PM2 · Meeting Room 6','Platinum'),
+('PM3','PM3 · Meeting Room 7','Platinum'),
+('PM4','PM4 · Meeting Room 8','Platinum'),
+('GM1','GM1 · Meeting Room 9','Gold'),
+('GM2','GM2 · Outdoor Meeting Room 1 (Hyundai Office Bus)','Other'),
+('GM3','GM3 · Outdoor Meeting Room 2 (Hyundai Office Bus)','Other'),
+('NM1','NM1 · Media Interview Room','Other');
 
 -- seed companies (idempotent)
 INSERT IGNORE INTO companies(name, tier) VALUES
 -- Diamond
-('MEBO','Diamond'),
-('UPbit','Diamond'),
-('Korea Hydro & Nuclear Power Co., Ltd. (KHNP)','Diamond'),
-('SK hynix Inc.','Diamond'),
 ('Samsung','Diamond'),
-('Posco Holdings','Diamond'),
-('Hyundai Motor Group','Diamond'),
+('SK','Diamond'),
+('Hyundai','Diamond'),
+('LG','Diamond'),
+('Lotte','Diamond'),
+('Posco International','Diamond'),
 ('Hanwha','Diamond'),
+('HD Hyundai','Diamond'),
 ('GS','Diamond'),
+('Shinsegae Group','Diamond'),
+('Korea Hydro & Nuclear Power','Diamond'),
+('UPbit','Diamond'),
+('Hybe','Diamond'),
+('Mebo','Diamond'),
 
 -- Platinum
-('KB Kookmin Bank','Platinum'),
-('MegazoneCloud','Platinum'),
-('Woori Bank','Platinum'),
-('LS Corp.','Platinum'),
-('Wuliangye','Platinum'),
-('Citi','Platinum'),
-('Johnson & Johnson','Platinum'),
+('Korean Air Lines','Platinum'),
+('LS','Platinum'),
 ('Doosan','Platinum'),
+('KT','Platinum'),
+('Naver','Platinum'),
 ('Shinhan Bank','Platinum'),
-('NAVER Corporation','Platinum'),
-('TikTok','Platinum'),
+('Kookmin Bank','Platinum'),
+('Woori Bank','Platinum'),
+('Hana Bank','Platinum'),
+('CJ','Platinum'),
+('Korea zinc','Platinum'),
+('Megazone Cloud','Platinum'),
+('Kolon','Platinum'),
+('HS Hyosung','Platinum'),
+('Citi','Platinum'),
+('Meta','Platinum'),
+('AWS','Platinum'),
+('Johnsons&Johnson','Platinum'),
+('Coupang','Platinum'),
+('TicTok','Platinum'),
+('Wuliangye','Platinum'),
 
 -- Gold
+('AB InBev','Gold'),
+('Ananti','Gold'),
 ('Microsoft','Gold'),
-('Google Korea','Gold');
+('Google','Gold'),
+('LONGi','Gold'),
+('Vobile','Gold'),
+
+-- Partners
+('Kim & Chang','Legal Partner'),
+('Deloitte','Knowledge Partner'),
+('Bloomberg','Media Partner - Premier'),
+('Caixin','Media Partner - Premier'),
+('CGTN','Media Partner - Premier'),
+('CNBC','Media Partner - Premier'),
+('Economist Imapct','Media Partner - Platinum'),
+('Financial Times','Media Partner - Gold'),
+('Foreign Affairs','Media Partner - Gold'),
+('Time','Media Partner - Gold'),
+('The Wall Street Journal','Media Partner - Gold');
 

--- a/static/booking.html
+++ b/static/booking.html
@@ -34,16 +34,21 @@
 </main>
 <script>
 const ROOM_LABEL = {
-  'DM1':'DM1 · Meeting Room 1','DM2':'DM2 · Meeting Room 2','DM3':'DM3 · Meeting Room 3','DM4':'DM4 · Outdoor F&B Zone, Office Bus',
-  'PM1':'PM1 · Meeting Room 1','PM2':'PM2 · Meeting Room 2','PM3':'PM3 · Meeting Room 3','PM4':'PM4 · Outdoor F&B Zone, Office Bus',
-  'GM1':'GM1 · Meeting Room 1','GM2':'GM2 · Meeting Room 2','GM3':'GM3 · Meeting Room 3',
-  'NM1':'NM1 · MAIN ENTERANCE'
+  'DM1':'DM1 · Meeting Room 1','DM2':'DM2 · Meeting Room 2','DM3':'DM3 · Meeting Room 3','DM4':'DM4 · Meeting Room 4',
+  'PM1':'PM1 · Meeting Room 5','PM2':'PM2 · Meeting Room 6','PM3':'PM3 · Meeting Room 7','PM4':'PM4 · Meeting Room 8',
+  'GM1':'GM1 · Meeting Room 9','GM2':'GM2 · Outdoor Meeting Room 1 (Hyundai Office Bus)','GM3':'GM3 · Outdoor Meeting Room 2 (Hyundai Office Bus)',
+  'NM1':'NM1 · Media Interview Room'
 };
 const ROOM_MAP = {
-  'Diamond':['DM1','DM2','DM3','DM4'],
-  'Platinum':['PM1','PM2','PM3','PM4'],
-  'Gold':['GM1','GM2','GM3'],
-  'General':['NM1']
+  'Diamond':['DM1','DM2','DM3','DM4','PM1','PM2','PM3','PM4','GM1'],
+  'Platinum':['DM1','DM2','DM3','DM4','PM1','PM2','PM3','PM4','GM1'],
+  'Gold':['DM1','DM2','DM3','DM4','PM1','PM2','PM3','PM4','GM1'],
+  'Legal Partner':['DM1','DM2','DM3','DM4','PM1','PM2','PM3','PM4','GM1'],
+  'Knowledge Partner':['DM1','DM2','DM3','DM4','PM1','PM2','PM3','PM4','GM1'],
+  'Media Partner - Premier':['GM2','GM3','NM1'],
+  'Media Partner - Platinum':['GM2','GM3','NM1'],
+  'Media Partner - Gold':['GM2','GM3','NM1'],
+  'Other':['GM2','GM3']
 };
 const EVENT_START='2025-10-29', EVENT_END='2025-10-31';
 

--- a/static/display.html
+++ b/static/display.html
@@ -26,10 +26,10 @@ th{background:#111827}
 const params=new URLSearchParams(location.search);
 const room=params.get('room')||'DM1';
 const label={
-  'DM1':'DM1 · Meeting Room 1','DM2':'DM2 · Meeting Room 2','DM3':'DM3 · Meeting Room 3','DM4':'DM4 · Outdoor F&B Zone, Office Bus',
-  'PM1':'PM1 · Meeting Room 1','PM2':'PM2 · Meeting Room 2','PM3':'PM3 · Meeting Room 3','PM4':'PM4 · Outdoor F&B Zone, Office Bus',
-  'GM1':'GM1 · Meeting Room 1','GM2':'GM2 · Meeting Room 2','GM3':'GM3 · Meeting Room 3',
-  'NM1':'NM1 · MAIN ENTERANCE'
+  'DM1':'DM1 · Meeting Room 1','DM2':'DM2 · Meeting Room 2','DM3':'DM3 · Meeting Room 3','DM4':'DM4 · Meeting Room 4',
+  'PM1':'PM1 · Meeting Room 5','PM2':'PM2 · Meeting Room 6','PM3':'PM3 · Meeting Room 7','PM4':'PM4 · Meeting Room 8',
+  'GM1':'GM1 · Meeting Room 9','GM2':'GM2 · Outdoor Meeting Room 1 (Hyundai Office Bus)','GM3':'GM3 · Outdoor Meeting Room 2 (Hyundai Office Bus)',
+  'NM1':'NM1 · Media Interview Room'
 };
 const HOURS=Array.from({length:17},(_,i)=>i+6);
 function fmt(h){return String(h).padStart(2,'0')+':00'}

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -129,6 +129,7 @@
   const EVENT_DATES    = {{ event_dates|tojson|safe }};
   const ALL_ROOMS      = {{ all_room_codes|tojson|safe }};
   const ROOM_LABEL     = {{ room_label|tojson|safe }};
+  const ROOMS_BY_TIER  = {{ rooms_by_tier|tojson|safe }};
   const HOURS          = {{ hours|tojson|safe }};
   const MAX_BLOCKS     = {{ max_blocks|tojson|safe }};
   const INITIAL_DATE   = {{ initial_date|tojson|safe }};
@@ -173,14 +174,20 @@
   }
   function isOtherSelected(){ return $('#company').value === 'Other'; }
 
+  function roomsForTier(tier){
+    const codes = ROOMS_BY_TIER && ROOMS_BY_TIER[tier];
+    return Array.isArray(codes) ? codes.slice() : [];
+  }
+
   function populateRooms(codes){
     const sel = $('#room');
     const previous = sel.value;
-    sel.innerHTML = codes.map(code => `<option value="${code}">${ROOM_LABEL[code]||code}</option>`).join('');
-    if(previous && codes.includes(previous)){
+    const list = Array.isArray(codes) && codes.length ? codes : ALL_ROOMS;
+    sel.innerHTML = list.map(code => `<option value="${code}">${ROOM_LABEL[code]||code}</option>`).join('');
+    if(previous && list.includes(previous)){
       sel.value = previous;
-    } else if(codes.length){
-      sel.value = codes[0];
+    } else if(list.length){
+      sel.value = list[0];
     }
   }
 
@@ -188,7 +195,7 @@
     $('#companyOtherField').classList.remove('hidden');
     $('#tierView').value = 'Other';
     $('#tier').value = 'Other';
-    populateRooms(ALL_ROOMS);
+    populateRooms(roomsForTier('Other'));
   }
   function exitOtherMode(){
     $('#companyOtherField').classList.add('hidden');
@@ -204,7 +211,8 @@
     const tier = opt?.dataset?.tier || '';
     $('#tierView').value = tier || '(Unknown)';
     $('#tier').value = tier || '';
-    populateRooms(ALL_ROOMS);
+    const allowed = roomsForTier(tier);
+    populateRooms(allowed);
   }
 
   // 시작 옵션

--- a/templates/rooms.html
+++ b/templates/rooms.html
@@ -96,7 +96,9 @@
     <ul class="guide-notes">
       <li><strong>Meeting rooms</strong> are available for reservation <span class="highlight">up to two times per day</span>, with each session <span class="highlight">limited to 45 minutes.</span></li>
       <li>Explore the meeting rooms curated for <strong>APEC CEO Summit Korea 2025</strong>. Tap the room to see detailed amenities.</li>
-      <li>All registered companies — including <strong>Other</strong> entries — can reserve <strong>any meeting room</strong>.</li>
+      <li><strong>Meeting Rooms 1–9</strong> are available to <strong>Diamond</strong>, <strong>Platinum</strong>, <strong>Gold</strong>, <strong>Legal Partner</strong>, and <strong>Knowledge Partner</strong> tiers.</li>
+      <li><strong>Outdoor Meeting Rooms 1 &amp; 2</strong> and the <strong>Media Interview Room</strong> are allocated to <strong>Media Partner - Premier</strong>, <strong>Media Partner - Platinum</strong>, and <strong>Media Partner - Gold</strong> tiers.</li>
+      <li><strong>Other</strong> entries may reserve <strong>Outdoor Meeting Rooms 1 &amp; 2</strong>.</li>
     </ul>
 
     <div class="room-card-grid">


### PR DESCRIPTION
## Summary
- clear the companies table before seeding so only the latest sponsor list remains
- insert the updated sponsor lineup without relying on INSERT IGNORE
- widen the companies.tier ENUM before seeding so partner tiers load without errors

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f2e453d88323b69f1d275db26e8a