### PR TITLE
Ensure companies tier enum supports partner levels

### DIFF
--- a/create_companies.sh
+++ b/create_companies.sh
@@ -83,6 +83,13 @@ CREATE TABLE IF NOT EXISTS companies (
   INDEX idx_tier_name (tier, name)
 ) ENGINE=InnoDB;
 
+-- Ensure enum list matches seed data even if table already existed
+ALTER TABLE companies
+  MODIFY COLUMN tier ENUM(
+    'Diamond','Platinum','Gold','Legal Partner','Knowledge Partner',
+    'Media Partner - Premier','Media Partner - Platinum','Media Partner - Gold'
+  ) NOT NULL;
+
 -- Reset and seed companies
 DELETE FROM companies;
 ALTER TABLE companies AUTO_INCREMENT = 1;


### PR DESCRIPTION
## Summary
- align the companies.tier enum definition with the partner tiers seeded by the script
- alter the existing companies table to refresh the enum list before reseeding data

## Testing
- not run (mysql client/server not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0f7df20488323abea5d0aa1416fea