### PR TITLE
Handle extended room tiers during room seeding

### DIFF
--- a/models.sql
+++ b/models.sql
@@ -8,7 +8,10 @@ CREATE TABLE IF NOT EXISTS rooms (
   id INT PRIMARY KEY AUTO_INCREMENT,
   code VARCHAR(64) NOT NULL UNIQUE,
   label VARCHAR(120) NOT NULL,
-  tier ENUM('Diamond','Platinum','Gold','Other') NOT NULL
+  tier ENUM(
+    'Diamond','Platinum','Gold','Legal Partner','Knowledge Partner',
+    'Media Partner - Premier','Media Partner - Platinum','Media Partner - Gold','Other'
+  ) NOT NULL
 ) ENGINE=InnoDB;
 
 -- Bookings


### PR DESCRIPTION
## Summary
- ensure the rooms seeding step expands the tier enum when new partner tiers are configured and normalizes unexpected values
- extend the SQL schema definition so the rooms table accepts every configured partner tier

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e0fae0ab8483239f7272c1cd7b33b7