### PR TITLE
Update logo asset and typography for booking interface

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,19 @@
+@font-face{
+  font-family:'NotoSansCJKkr';
+  src:url('/static/fonts/NotoSansCJKkr-Medium_0.otf') format('opentype');
+  font-weight:500;
+  font-style:normal;
+  font-display:swap;
+}
+
+@font-face{
+  font-family:'NotoSansCJKkr';
+  src:url('/static/fonts/NotoSansCJKkr-Black_0.otf') format('opentype');
+  font-weight:900;
+  font-style:normal;
+  font-display:swap;
+}
+
 :root{
   --bg:#0e1726;
   --card:#121b2a;
@@ -23,9 +39,12 @@
 *{box-sizing:border-box}
 html,body{height:100%}
 body{
-  margin:0; background:var(--bg); color:var(--text);
-  font:400 var(--fs-md)/1.5 ui-sans-serif,system-ui,Segoe UI,Roboto,Apple SD Gothic Neo,Malgun Gothic,Apple Color Emoji,Segoe UI Emoji;
-  -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
+  margin:0;
+  background:var(--bg);
+  color:var(--text);
+  font:500 var(--fs-md)/1.5 'NotoSansCJKkr',ui-sans-serif,system-ui,Segoe UI,Roboto,Apple SD Gothic Neo,Malgun Gothic,Apple Color Emoji,Segoe UI Emoji;
+  -webkit-font-smoothing:antialiased;
+  -moz-osx-font-smoothing:grayscale;
 }
 
 a{color:#9ac0ff; text-decoration:none}
@@ -33,11 +52,14 @@ a:hover{text-decoration:underline}
 
 .topbar{position:sticky;top:0;z-index:20;background:#0c1422;box-shadow:var(--shadow)}
 .topbar-inner{max-width:1200px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:12px 16px}
-.brand{display:flex;flex-direction:column;align-items:flex-start;gap:6px}
-.brand-logo{display:inline-flex}
+.brand{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.brand-logo{display:inline-flex;align-items:center}
 .brand img{height:48px;width:auto}
 .brand-caption{
-  font-weight:800;
+  display:inline-flex;
+  align-items:center;
+  font-family:'NotoSansCJKkr',ui-sans-serif,system-ui,Segoe UI,Roboto,Apple SD Gothic Neo,Malgun Gothic,Apple Color Emoji,Segoe UI Emoji;
+  font-weight:900;
   font-size:var(--fs-lg);
   letter-spacing:0.14em;
   text-transform:uppercase;

--- a/templates/1
+++ b/templates/1
@@ -28,7 +28,7 @@
   <div class="topbar-inner">
     <div class="brand">
       <a href="/" class="brand-logo" aria-label="Home">
-        <img src="/static/logo-apec.svg" alt="APEC" />
+        <img src="/static/logo-apec.png" alt="APEC" />
       </a>
       <div class="title">
         <span class="eyebrow">APEC CEO Summit Korea 2025</span>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -31,7 +31,7 @@
   <div class="topbar-inner">
     <div class="brand">
       <a href="/" class="brand-logo" aria-label="Home">
-        <img src="/static/logo-apec.svg" alt="APEC" />
+        <img src="/static/logo-apec.png" alt="APEC" />
       </a>
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -33,7 +33,7 @@
   <div class="topbar-inner">
     <div class="brand">
       <a href="/" class="brand-logo" aria-label="Home">
-        <img src="/static/logo-apec.svg" alt="APEC" />
+        <img src="/static/logo-apec.png" alt="APEC" />
       </a>
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>

--- a/templates/display.html
+++ b/templates/display.html
@@ -12,7 +12,7 @@
   <div class="topbar-inner">
     <div class="brand">
       <a href="/" class="brand-logo" aria-label="Home">
-        <img src="/static/logo-apec.svg" alt="APEC" />
+        <img src="/static/logo-apec.png" alt="APEC" />
       </a>
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>

--- a/templates/launcher.html
+++ b/templates/launcher.html
@@ -12,7 +12,7 @@
   <div class="topbar-inner">
     <div class="brand">
       <a href="/" class="brand-logo" aria-label="Home">
-        <img src="/static/logo-apec.svg" alt="APEC" />
+        <img src="/static/logo-apec.png" alt="APEC" />
       </a>
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>

--- a/templates/room_detail.html
+++ b/templates/room_detail.html
@@ -27,7 +27,7 @@
   <div class="topbar-inner">
     <div class="brand">
       <a href="/" class="brand-logo" aria-label="Home">
-        <img src="/static/logo-apec.svg" alt="APEC" />
+        <img src="/static/logo-apec.png" alt="APEC" />
       </a>
       <span class="brand-caption">MEETING ROOM RESERVATION</span>
     </div>

--- a/templates/rooms.html
+++ b/templates/rooms.html
@@ -80,10 +80,10 @@
   <div class="topbar-inner">
       <div class="brand">
         <a href="/" class="brand-logo" aria-label="Home">
-          <img src="/static/logo-apec.svg" alt="APEC" />
+          <img src="/static/logo-apec.png" alt="APEC" />
         </a>
-      <span class="brand-caption">MEETING ROOM RESERVATION</span>
-    </div>
+        <span class="brand-caption">MEETING ROOM RESERVATION</span>
+      </div>
     <nav class="nav">
       <a href="/booking" class="button">Back to Booking</a>
     </nav>


### PR DESCRIPTION
## Summary
- load the new Noto Sans CJK KR fonts globally and adjust the header brand layout so the caption sits beside the logo
- switch all templates to use the PNG logo asset for the header artwork

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e10d5c66d48323b8a64fdac0eccd88