### PR TITLE
Add real room photography to room pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from urllib.parse import quote_plus
+from urllib.parse import quote, quote_plus
 from typing import List, Dict, Any, Tuple, Optional
 
 from fastapi import FastAPI, Request, Form, HTTPException
@@ -59,7 +59,7 @@ ROOMS_DATA = [
         "meeting_code": "DM1",
         "summary": "",
         "features": ["Sofa and Table", "TV", "HDMI"],
-        "image": "/static/images/rooms/indoor-suite.svg",
+        "image": f"/static/rooms/{quote('Meeting Room 1.jpg')}",
         "order": 1,
     },
     {
@@ -72,7 +72,7 @@ ROOMS_DATA = [
         "meeting_code": "DM2",
         "summary": "",
         "features": ["Chair and Table", "Delegation Mic.", "Podium"],
-        "image": "/static/images/rooms/indoor-suite.svg",
+        "image": f"/static/rooms/{quote('Meeting Room 2.jpg')}",
         "order": 2,
     },
     {
@@ -85,7 +85,7 @@ ROOMS_DATA = [
         "meeting_code": "DM3",
         "summary": "",
         "features": ["Sofa and Table"],
-        "image": "/static/images/rooms/indoor-suite.svg",
+        "image": f"/static/rooms/{quote('Meeting Room 3.png')}",
         "order": 3,
     },
     {
@@ -98,7 +98,7 @@ ROOMS_DATA = [
         "meeting_code": "DM4",
         "summary": "",
         "features": ["Sofa and Table"],
-        "image": "/static/images/rooms/outdoor-terrace.svg",
+        "image": f"/static/rooms/{quote('Meeting Room 4.jpg')}",
         "order": 4,
     },
     {
@@ -111,7 +111,7 @@ ROOMS_DATA = [
         "meeting_code": "PM1",
         "summary": "",
         "features": ["Sofa and Table"],
-        "image": "/static/images/rooms/indoor-suite.svg",
+        "image": f"/static/rooms/{quote('Meeting Room 5.jpg')}",
         "order": 1,
     },
     {
@@ -124,7 +124,7 @@ ROOMS_DATA = [
         "meeting_code": "PM2",
         "summary": "",
         "features": ["Sofa and Table"],
-        "image": "/static/images/rooms/indoor-suite.svg",
+        "image": f"/static/rooms/{quote('Meeting Room 6.jpg')}",
         "order": 2,
     },
     {
@@ -137,7 +137,7 @@ ROOMS_DATA = [
         "meeting_code": "PM3",
         "summary": "",
         "features": ["Sofa and Table"],
-        "image": "/static/images/rooms/indoor-suite.svg",
+        "image": f"/static/rooms/{quote('Meeting Room 7.png')}",
         "order": 3,
     },
     {
@@ -150,7 +150,7 @@ ROOMS_DATA = [
         "meeting_code": "PM4",
         "summary": "",
         "features": ["Sofa and Table"],
-        "image": "/static/images/rooms/outdoor-terrace.svg",
+        "image": f"/static/rooms/{quote('Meeting Room 8.jpg')}",
         "order": 4,
     },
     {
@@ -163,7 +163,7 @@ ROOMS_DATA = [
         "meeting_code": "GM1",
         "summary": "",
         "features": ["Sofa and Table"],
-        "image": "/static/images/rooms/indoor-suite.svg",
+        "image": f"/static/rooms/{quote('Meeting Room 9.png')}",
         "order": 1,
     },
     {
@@ -176,7 +176,7 @@ ROOMS_DATA = [
         "meeting_code": "GM2",
         "summary": "",
         "features": [],
-        "image": "/static/images/rooms/indoor-suite.svg",
+        "image": f"/static/rooms/{quote('Outdoor Meeting Room 1 (Hyundai Office Bus).png')}",
         "order": 2,
     },
     {
@@ -189,7 +189,7 @@ ROOMS_DATA = [
         "meeting_code": "GM3",
         "summary": "",
         "features": [],
-        "image": "/static/images/rooms/indoor-suite.svg",
+        "image": f"/static/rooms/{quote('Outdoor Meeting Room 2 (Hyundai Office Bus).png')}",
         "order": 3,
     },
     {
@@ -202,7 +202,7 @@ ROOMS_DATA = [
         "meeting_code": "NM1",
         "summary": "",
         "features": ["Sofa and Table"],
-        "image": "/static/images/rooms/outdoor-terrace.svg",
+        "image": f"/static/rooms/{quote('Media Interview Room.jpg')}",
         "order": 1,
     },
 ]

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -38,7 +38,7 @@
     </div>
     <div class="topbar-title">MEETING ROOM RESERVATION</div>
     <nav class="nav">
-      <a href="/rooms" class="button">Room Guide</a>
+      <a href="/rooms" class="button">Room<br />Information</a>
     </nav>
   </div>
 </header>

--- a/templates/room_detail.html
+++ b/templates/room_detail.html
@@ -8,9 +8,9 @@
   <link rel="icon" type="image/x-icon" href="https://www.apecceosummitkorea2025.com/images/favicon.ico" />
   <style>
     .hero{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:28px;align-items:center}
-    .hero-visual{position:relative;border-radius:24px;border:1px solid rgba(255,255,255,0.12);background:linear-gradient(160deg,rgba(16,28,48,0.95),rgba(12,20,36,0.95));padding:24px;display:flex;align-items:center;justify-content:center;box-shadow:var(--shadow)}
-    .hero-visual img{width:160px;height:160px;object-fit:contain;filter:drop-shadow(0 16px 36px rgba(0,0,0,0.45));}
-    .hero-category{position:absolute;bottom:18px;left:18px;padding:6px 14px;border-radius:10px;border:1px solid rgba(255,255,255,0.14);background:rgba(9,17,32,0.75);font-size:var(--fs-xs,13px);letter-spacing:0.08em;text-transform:uppercase;color:#dbe6ff}
+    .hero-visual{position:relative;border-radius:24px;border:1px solid rgba(255,255,255,0.12);background:#060b15;overflow:hidden;box-shadow:var(--shadow);aspect-ratio:4/3}
+    .hero-visual img{width:100%;height:100%;object-fit:cover;display:block}
+    .hero-category{position:absolute;top:18px;left:18px;padding:6px 14px;border-radius:10px;border:1px solid rgba(255,255,255,0.14);background:rgba(9,17,32,0.75);font-size:var(--fs-xs,13px);letter-spacing:0.08em;text-transform:uppercase;color:#dbe6ff}
     .hero-details{display:flex;flex-direction:column;gap:14px}
     .hero-meta{display:grid;gap:10px;margin:0}
     .hero-meta div{display:flex;justify-content:space-between;gap:12px;font-size:var(--fs-sm);color:#dbe6ff}
@@ -32,7 +32,7 @@
     </div>
     <div class="topbar-title">MEETING ROOM RESERVATION</div>
     <nav class="nav">
-      <a href="/rooms" class="button">Room Guide</a>
+      <a href="/rooms" class="button">Room<br />Information</a>
       <a href="/booking" class="button">Booking</a>
     </nav>
   </div>

--- a/templates/rooms.html
+++ b/templates/rooms.html
@@ -40,16 +40,21 @@
       position:relative;
       border-radius:16px;
       border:1px solid rgba(255,255,255,0.1);
-      background:#0b1424;
-      padding:14px;
-      display:flex;
-      align-items:center;
-      justify-content:center;
+      background:#060b15;
+      overflow:hidden;
+      aspect-ratio:4/3;
     }
-    .room-card-image img{width:100px;height:100px;object-fit:contain;filter:drop-shadow(0 12px 24px rgba(0,0,0,0.35));}
+    .room-card-image img{
+      width:100%;
+      height:100%;
+      object-fit:cover;
+      display:block;
+      transition:transform 0.4s ease;
+    }
+    .room-card:hover .room-card-image img{transform:scale(1.03);}
     .room-category{
       position:absolute;
-      bottom:12px;
+      top:12px;
       left:12px;
       background:rgba(9,17,32,0.85);
       border:1px solid rgba(255,255,255,0.12);
@@ -71,7 +76,6 @@
     .room-card .button{background:#ffd166;color:#0b1020;font-weight:700}
     @media (max-width:768px){
       .room-card{padding:16px}
-      .room-card-image img{width:88px;height:88px}
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- update the room catalog to point at the JPG/PNG assets under `/static/rooms`
- refresh the rooms and room detail layouts so the new photography fills the cards and hero banner
- change the navigation button label to the two-line "Room / Information" format requested

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e119ad14148323a4ad75c0324c0a12