### PR TITLE
Remove room category overlays and plan section copy

### DIFF
--- a/templates/room_detail.html
+++ b/templates/room_detail.html
@@ -10,7 +10,6 @@
     .hero{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:28px;align-items:center}
     .hero-visual{position:relative;border-radius:24px;border:1px solid rgba(255,255,255,0.12);background:#060b15;overflow:hidden;box-shadow:var(--shadow);aspect-ratio:4/3}
     .hero-visual img{width:100%;height:100%;object-fit:cover;display:block}
-    .hero-category{position:absolute;top:18px;left:18px;padding:6px 14px;border-radius:10px;border:1px solid rgba(255,255,255,0.14);background:rgba(9,17,32,0.75);font-size:var(--fs-xs,13px);letter-spacing:0.08em;text-transform:uppercase;color:#dbe6ff}
     .hero-details{display:flex;flex-direction:column;gap:14px}
     .hero-meta{display:grid;gap:10px;margin:0}
     .hero-meta div{display:flex;justify-content:space-between;gap:12px;font-size:var(--fs-sm);color:#dbe6ff}
@@ -18,8 +17,6 @@
     .hero-meta dd{margin:0;font-weight:700}
     .feature-list{display:flex;flex-wrap:wrap;gap:10px;margin:0;padding:0;list-style:none}
     .feature-list li{border:1px solid rgba(255,255,255,0.18);border-radius:999px;padding:8px 16px;background:rgba(255,255,255,0.06)}
-    .info-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;margin-top:20px}
-    .info-card{background:#101a2c;border:1px solid var(--line);border-radius:var(--radius);padding:16px;box-shadow:var(--shadow)}
   </style>
 </head>
 <body>
@@ -44,7 +41,6 @@
     <div class="hero">
       <div class="hero-visual">
         <img src="{{ details.image }}" alt="{{ room_name }}" loading="lazy" />
-        <span class="hero-category">{{ details.category }}</span>
       </div>
       <div class="hero-details">
         <h1 class="title" style="margin:0">{{ room_name }}</h1>
@@ -62,22 +58,7 @@
   </section>
 
   <section class="card">
-    <h2 class="title">Plan your meeting</h2>
-    <div class="info-grid">
-      <div class="info-card">
-        <h3 style="margin-top:0">Best for</h3>
-        <p class="muted">Sponsor networking, leadership sessions and curated hospitality moments.</p>
-      </div>
-      <div class="info-card">
-        <h3 style="margin-top:0">Setup options</h3>
-        <p class="muted">Boardroom, lounge or standing table layouts. Concierge support can refresh the room within 15 minutes.</p>
-      </div>
-      <div class="info-card">
-        <h3 style="margin-top:0">Connectivity</h3>
-        <p class="muted">High-bandwidth Wi-Fi, HDMI/USB-C hub and dedicated AV technician support on standby.</p>
-      </div>
-    </div>
-    <div style="margin-top:24px;display:flex;flex-wrap:wrap;gap:12px">
+    <div style="display:flex;flex-wrap:wrap;gap:12px">
       <a class="button" href="/booking">Book this room</a>
     </div>
   </section>

--- a/templates/rooms.html
+++ b/templates/rooms.html
@@ -52,19 +52,6 @@
       transition:transform 0.4s ease;
     }
     .room-card:hover .room-card-image img{transform:scale(1.03);}
-    .room-category{
-      position:absolute;
-      top:12px;
-      left:12px;
-      background:rgba(9,17,32,0.85);
-      border:1px solid rgba(255,255,255,0.12);
-      border-radius:10px;
-      padding:4px 10px;
-      font-size:var(--fs-xs,13px);
-      color:#dbe6ff;
-      text-transform:uppercase;
-      letter-spacing:0.08em;
-    }
     .room-name{margin:0;font-size:var(--fs-lg);font-weight:800;text-transform:uppercase;letter-spacing:0.05em}
     .room-meta{display:grid;gap:8px}
     .room-meta div{display:flex;justify-content:space-between;gap:12px;font-size:var(--fs-sm);color:#d5e3ff}
@@ -111,7 +98,6 @@
       <article class="room-card">
         <div class="room-card-image">
           <img src="{{ room.image }}" alt="{{ room.name }}" loading="lazy" />
-          <span class="room-category">{{ room.category }}</span>
         </div>
         <h3 class="room-name">{{ room.name }}</h3>
         <dl class="room-meta">


### PR DESCRIPTION
## Summary
- remove category badges from room listing cards and detail hero images
- simplify room detail content by dropping the "Plan your meeting" copy while keeping the booking action

## Testing
- uvicorn app:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68e11b879a68832390d3544c215ccd20