### PR TITLE
Remove admin link from display view header

### DIFF
--- a/templates/display.html
+++ b/templates/display.html
@@ -16,9 +16,6 @@
       </a>
     </div>
     <div class="topbar-title">MEETING ROOM RESERVATION</div>
-    <nav class="nav">
-      <a href="/admin" class="button">Admin</a>
-    </nav>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary
- remove the Admin navigation button from the display page header to hide the admin shortcut

## Testing
- not run (database connection required for the display endpoint)


------
https://chatgpt.com/codex/tasks/task_e_68e123fce8f08323a24c21fe58a5859e