### PR TITLE
Highlight current hour on display board

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -117,6 +117,9 @@ input:focus,select:focus{border-color:#4a68ff;box-shadow:0 0 0 3px rgba(68,85,25
 .table td{font-size:var(--fs-md)}
 .table-scroll{overflow:auto; -webkit-overflow-scrolling:touch}
 
+.table tr.is-current{outline:2px solid #ffd166;outline-offset:-2px;background:rgba(255,209,102,.08)}
+.table tr.is-current td{border-bottom-color:rgba(255,209,102,.5)}
+
 /* Status colors */
 .ok{color:var(--ok);font-weight:700}
 .no{color:#ff7676;font-weight:700}

--- a/templates/display.html
+++ b/templates/display.html
@@ -76,7 +76,7 @@
         status = '<b class="ok">Available</b>';
         company = '';
       }
-      html += `<tr>
+      html += `<tr data-hour="${h}">
         <td data-label="Time">${fmt(h)} – ${fmt(h+1)}</td>
         <td data-label="Status">${status}</td>
         <td data-label="Company">${company}</td>
@@ -88,6 +88,45 @@
     const ts = new Date().toLocaleTimeString();
     const lu = $('#lastUpdated');
     if (lu) lu.textContent = 'Updated: ' + ts;
+    highlightCurrentSlot();
+  }
+
+  function highlightCurrentSlot(){
+    const grid = $('#grid');
+    if(!grid) return;
+
+    grid.querySelectorAll('tbody tr').forEach(row => row.classList.remove('is-current'));
+
+    if(!DATE) return;
+    const parts = DATE.split('-').map(Number);
+    if(parts.length !== 3) return;
+
+    const [year, month, day] = parts;
+    if(!year || !month || !day) return;
+
+    const today = new Date();
+    const target = new Date(year, month - 1, day);
+    if(
+      today.getFullYear() !== target.getFullYear() ||
+      today.getMonth() !== target.getMonth() ||
+      today.getDate() !== target.getDate()
+    ){
+      return;
+    }
+
+    if(!HOURS || !HOURS.length) return;
+    const startHour = HOURS[0];
+    const endHour = HOURS[HOURS.length - 1];
+
+    let hour = today.getHours();
+    if(hour < startHour){
+      hour = startHour;
+    }else if(hour > endHour){
+      hour = endHour;
+    }
+
+    const row = grid.querySelector(`tbody tr[data-hour="${hour}"]`);
+    if(row) row.classList.add('is-current');
   }
 
   async function refresh(){


### PR DESCRIPTION
## Summary
- add metadata to display board rows so the current slot can be targeted
- highlight the current hour when the board is showing today, clamping to the schedule
- style the highlighted row with a yellow outline to match the request

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e125af66088323a57a415657cea047