### PR TITLE
Add temporary October 5 date for display highlight testing

### DIFF
--- a/templates/1
+++ b/templates/1
@@ -214,8 +214,8 @@
 
   function defaultDate(){
     const today = new Date().toISOString().slice(0,10);
-    if (today >= EVENT_DATES[0] && today <= EVENT_DATES[EVENT_DATES.length-1]) return today;
-    return EVENT_DATES[0];
+    const upcoming = EVENT_DATES.find(d => today <= d);
+    return upcoming || EVENT_DATES[0];
   }
 
   function initFromURL(){

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -359,8 +359,8 @@
   function defaultDate(){
     if (INITIAL_DATE) return INITIAL_DATE;
     const today = new Date().toISOString().slice(0,10);
-    if (today >= EVENT_DATES[0] && today <= EVENT_DATES[EVENT_DATES.length-1]) return today;
-    return EVENT_DATES[0];
+    const upcoming = EVENT_DATES.find(d => today <= d);
+    return upcoming || EVENT_DATES[0];
   }
   function initFromURL(){
     const p = new URLSearchParams(location.search);

--- a/templates/launcher.html
+++ b/templates/launcher.html
@@ -38,7 +38,8 @@
   const EVENT_DATES = {{ event_dates|tojson|safe }};
   const ALL_ROOMS   = {{ all_room_codes|tojson|safe }};
   const ROOM_LABEL  = {{ room_label|tojson|safe }};
-  let chosenDate = EVENT_DATES[0];
+  const today = new Date().toISOString().slice(0,10);
+  let chosenDate = EVENT_DATES.find(d => today <= d) || EVENT_DATES[0];
 
   const dateRow = document.getElementById('dateButtons');
   const roomBlocks = document.getElementById('roomBlocks');


### PR DESCRIPTION
## Summary
- add October 5 to the event date list as a temporary display-highlight test option
- centralize the default event date selection in Python and mirror the logic in client templates

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e12841072883239d563ac45031038e