### PR TITLE
Add configurable booking window restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,42 @@ To queue the existing `send_email.sh` script so that it runs automatically at a 
 This command relies on the system `at` daemon. Make sure the `at` package is installed and the atd service is active. The script forwards the `ENV_FILE` and `DRY_RUN` environment variables (if provided) to `send_email.sh`.
 
 After scheduling, you can check pending jobs with `atq` and cancel a job with `atrm <job_id>`.
+
+## Database setup
+
+The application expects a MySQL schema that matches `models.sql`. The file is idempotent,
+so you can rerun it whenever new tables or columns are added. There are two common ways to
+apply it:
+
+### Using the MySQL CLI
+
+```bash
+mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" < models.sql
+```
+
+Replace the environment variables with the values from your deployment (they map to the
+`MYSQL_*` settings consumed by `app.py`). When prompted, enter the password for the MySQL
+user. This command will create any missing tables—including the booking window override
+table introduced for the reservation window feature—and seed the default room and company
+data.
+
+### From an interactive MySQL shell
+
+```bash
+mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p
+mysql> SOURCE /absolute/path/to/models.sql;
+```
+
+If your database runs inside Docker, prefix the commands with `docker exec -i <container>`
+so they run in the correct container, for example:
+
+```bash
+docker exec -i mysql-container mysql -u apec -p"secret" apec_booking < models.sql
+```
+
+Confirm the schema update by checking that the `booking_windows` table exists:
+
+```bash
+mysql> USE apec_booking;
+mysql> SHOW TABLES LIKE 'booking_windows';
+```

--- a/models.sql
+++ b/models.sql
@@ -50,6 +50,15 @@ CREATE TABLE IF NOT EXISTS disabled_slots (
   CONSTRAINT uq_disabled UNIQUE (room_code, date, start_hour, end_hour)
 ) ENGINE=InnoDB;
 
+-- Custom booking windows per event date
+CREATE TABLE IF NOT EXISTS booking_windows (
+  date DATE PRIMARY KEY,
+  start_at DATETIME NOT NULL,
+  end_at DATETIME NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
 -- Companies (신규)
 CREATE TABLE IF NOT EXISTS companies (
   id INT PRIMARY KEY AUTO_INCREMENT,

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -115,6 +115,79 @@
   </section>
 
   <section class="card">
+    <h2 class="title">Booking Window Settings</h2>
+
+    {% if window_error %}
+      <div class="alert error">{{ window_error }}</div>
+    {% elif window_msg %}
+      <div class="alert success">{{ window_msg }}</div>
+    {% endif %}
+
+    <form class="toolbar" method="post" action="/admin/booking-window" id="windowForm">
+      <label class="field">
+        <span>Event Date</span>
+        <select name="target_date" id="window-date" required>
+          {% for d in event_dates %}
+            <option value="{{ d }}" {% if d == date %}selected{% endif %}>{{ d }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="field">
+        <span>From (Date)</span>
+        <input type="date" name="start_date" id="window-start-date" required />
+      </label>
+      <label class="field">
+        <span>From (Time)</span>
+        <select name="start_hour" id="window-start-hour" required>
+          {% for h in range(0, 24) %}
+            <option value="{{ h }}">{{ "%02d:00" % h }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="field">
+        <span>To (Date)</span>
+        <input type="date" name="end_date" id="window-end-date" required />
+      </label>
+      <label class="field">
+        <span>To (Time)</span>
+        <select name="end_hour" id="window-end-hour" required>
+          {% for h in range(0, 25) %}
+            <option value="{{ h }}">{{ "24:00" if h == 24 else "%02d:00" % h }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      {% if room %}<input type="hidden" name="room" value="{{ room }}" />{% endif %}
+      <div style="display:flex;gap:8px;align-items:flex-end">
+        <button type="submit" class="button">Save Window</button>
+        <button type="submit" class="button" formaction="/admin/booking-window/reset">Reset to Default</button>
+      </div>
+    </form>
+
+    <div class="muted" id="windowSummary" style="margin-top:-4px;margin-bottom:12px"></div>
+
+    <div class="table-scroll">
+      <table class="table">
+        <thead>
+          <tr>
+            <th style="width:140px">Event Date</th>
+            <th>Window</th>
+            <th style="width:120px">Mode</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for w in window_rows %}
+            <tr>
+              <td>{{ w.date }}</td>
+              <td>{{ w.start }} → {{ w.end }}</td>
+              <td>{{ w.source }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="card">
     <h2 class="title">Manage Disabled Slots</h2>
 
     {% if disable_error %}
@@ -249,6 +322,41 @@
       </div>
     {% endfor %}
   </section>
+
+  <script>
+    const WINDOW_PRESETS = {{ booking_window_presets|tojson|safe }};
+    const TIMEZONE_LABEL = {{ timezone_label|tojson|safe }};
+    const windowDate = document.getElementById('window-date');
+    const windowStartDate = document.getElementById('window-start-date');
+    const windowStartHour = document.getElementById('window-start-hour');
+    const windowEndDate = document.getElementById('window-end-date');
+    const windowEndHour = document.getElementById('window-end-hour');
+    const windowSummary = document.getElementById('windowSummary');
+
+    function applyWindowPreset(date){
+      if(!WINDOW_PRESETS || !WINDOW_PRESETS[date]) return;
+      const info = WINDOW_PRESETS[date];
+      const form = info.form;
+      if(form){
+        windowStartDate.value = form.start_date;
+        windowStartHour.value = String(form.start_hour);
+        windowEndDate.value = form.end_date;
+        windowEndHour.value = String(form.end_hour);
+      }
+      const label = info.labels?.effective || '';
+      const mode = (info.effective?.source === 'custom') ? 'Custom' : 'Default';
+      windowSummary.textContent = label ? `Current window (${mode}, ${TIMEZONE_LABEL}): ${label}` : '';
+    }
+
+    if(windowDate){
+      windowDate.addEventListener('change', ()=>applyWindowPreset(windowDate.value));
+      const initial = windowDate.value || (windowDate.options[0]?.value ?? '');
+      if(initial){
+        windowDate.value = initial;
+        applyWindowPreset(initial);
+      }
+    }
+  </script>
 </main>
 <script>
   (function () {

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -106,6 +106,7 @@
       <div id="dailyWarn" class="flash" style="display:none; grid-column:1/-1"></div>
 
       <button class="button primary" type="submit" style="grid-column:1/-1">Reserve</button>
+      <div id="windowNotice" class="flash" style="display:none;grid-column:1/-1"></div>
       <div id="msg" class="muted" style="grid-column:1/-1"></div>
     </form>
   </section>
@@ -139,6 +140,15 @@
   const fmt = h => String(h).padStart(2,'0') + ':00';
 
   let desiredStartFromURL = null;
+  let windowAllowsBooking = true;
+  let dailyLimitAllowsBooking = true;
+
+  function updateSubmitState(){
+    const btn = document.querySelector('#bookingForm button[type="submit"]');
+    if(btn){
+      btn.disabled = !(windowAllowsBooking && dailyLimitAllowsBooking);
+    }
+  }
 
   // 달력
   function openCalendarPicker(){
@@ -155,6 +165,11 @@
   async function apiAvailability(date, room){
     const res = await fetch(`/api/availability?date=${encodeURIComponent(date)}&room=${encodeURIComponent(room)}`);
     if(!res.ok) throw new Error('failed to load availability');
+    return await res.json();
+  }
+  async function apiBookingWindow(date){
+    const res = await fetch(`/api/booking_window?date=${encodeURIComponent(date)}`);
+    if(!res.ok) throw new Error('failed to load booking window');
     return await res.json();
   }
   async function apiDailyCheck(date, company){
@@ -323,36 +338,87 @@
     renderBoard(date, room, data, blocks);
   }
 
+  async function updateWindowStatus(){
+    const notice = $('#windowNotice');
+    if(!notice){
+      windowAllowsBooking = true;
+      updateSubmitState();
+      return;
+    }
+    const date = $('#date').value;
+    if(!date){
+      windowAllowsBooking = true;
+      notice.style.display = 'none';
+      notice.textContent = '';
+      updateSubmitState();
+      return;
+    }
+    try{
+      const info = await apiBookingWindow(date);
+      if(info && info.is_open){
+        windowAllowsBooking = true;
+        notice.style.display = 'none';
+        notice.textContent = '';
+      }else{
+        windowAllowsBooking = false;
+        const label = (info && info.start_display && info.end_display)
+          ? `${info.start_display} ~ ${info.end_display}`
+          : '';
+        if(label){
+          notice.textContent = `현재 선택한 날짜는 예약 접수 시간이 아닙니다. 예약 가능 시간은 ${label} 입니다. 안내된 시간 외에는 예약이 불가능하오니 관리자에게 문의해 주세요.`;
+        }else{
+          notice.textContent = '현재 예약을 접수할 수 없습니다. 관리자에게 문의해 주세요.';
+        }
+        notice.style.display = '';
+      }
+    }catch(_err){
+      windowAllowsBooking = false;
+      notice.textContent = '예약 가능 시간을 불러오지 못했습니다. 관리자에게 문의해 주세요.';
+      notice.style.display = '';
+    }
+    updateSubmitState();
+  }
+
   // 하루 2시간 제한 사전 안내/차단
   async function checkDailyLimit(){
     const comp = $('#company').value;
     const date = $('#date').value;
     const warn = $('#dailyWarn');
-    const btn  = document.querySelector('#bookingForm button[type="submit"]');
-    if(!comp || !date){ warn.style.display='none'; btn.disabled=false; return; }
+    if(!comp || !date){
+      warn.style.display='none';
+      dailyLimitAllowsBooking = true;
+      updateSubmitState();
+      return;
+    }
 
     try{
       const j = await apiDailyCheck(date, comp);
-      if(!j || !j.ok){ warn.style.display='none'; btn.disabled=false; return; }
+      if(!j || !j.ok){
+        warn.style.display='none';
+        dailyLimitAllowsBooking = true;
+        updateSubmitState();
+        return;
+      }
       const limit = j.limit ?? 2;
       const already = j.total ?? 0;
       const want = parseInt($('#blocks').value,10)||1;
       if (already >= limit){
         warn.textContent = `Daily limit: ${comp} already has ${already}h booked on ${date}. Max ${limit}h/day.`;
         warn.style.display = '';
-        btn.disabled = true;
+        dailyLimitAllowsBooking = false;
       } else if (already + want > limit){
         warn.textContent = `Daily limit: ${comp} has ${already}h on ${date}. You can add only ${limit - already}h more.`;
         warn.style.display = '';
-        btn.disabled = true;
+        dailyLimitAllowsBooking = false;
       } else {
         warn.style.display = 'none';
-        btn.disabled = false;
+        dailyLimitAllowsBooking = true;
       }
     }catch(e){
       warn.style.display = 'none';
-      btn.disabled = false;
+      dailyLimitAllowsBooking = true;
     }
+    updateSubmitState();
   }
 
   // 기본값
@@ -380,7 +446,11 @@
       if(isOtherSelected()) $('#company_other').focus();
       await checkDailyLimit();
       await refreshAll();
-    }else if(['date','blocks'].includes(e.target.id)){
+    }else if(e.target.id==='date'){
+      await updateWindowStatus();
+      await checkDailyLimit();
+      await refreshAll();
+    }else if(e.target.id==='blocks'){
       await checkDailyLimit();
       await refreshAll();
     }else if(e.target.id==='room'){
@@ -390,9 +460,15 @@
 
   $('#bookingForm').addEventListener('submit', async (ev)=>{
     // 마지막 방어선: 프런트 체크
+    await updateWindowStatus();
     await checkDailyLimit();
     const warn = $('#dailyWarn');
-    if (warn.style.display !== 'none'){
+    if (!windowAllowsBooking){
+      ev.preventDefault();
+      $('#msg').textContent = '현재 예약 가능 시간이 아닙니다. 관리자에게 문의해 주세요.';
+      return false;
+    }
+    if (warn.style.display !== 'none' || !dailyLimitAllowsBooking){
       ev.preventDefault();
       return false;
     }
@@ -403,9 +479,11 @@
     await loadCompanies();
     initFromURL();
     applyTierFromCompany();
+    await updateWindowStatus();
     await checkDailyLimit();
     refreshAll().catch(()=>{});
     setInterval(refreshAll,60000);
+    setInterval(updateWindowStatus,60000);
   }
   init();
 </script>


### PR DESCRIPTION
## Summary
- enforce booking windows with default previous-day evening to morning window and expose status via API
- add admin controls and database storage for per-date booking window overrides
- disable booking UI outside the allowed window with clear guidance for contacting administrators

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e5f0a418a48323b040751c5d1fdbe1