### PR TITLE
Update booking email schedule link domain

### DIFF
--- a/send_email.sh
+++ b/send_email.sh
@@ -160,7 +160,7 @@ for email, company, tier, room, sh, eh, dt in rows:
 def fmt_time(h): return f"{h:02d}:00"
 
 
-SERVER_BASE_URL = os.environ.get("SERVER_BASE_URL", "http://99.79.51.11")
+SERVER_BASE_URL = os.environ.get("SERVER_BASE_URL", "http://apecmeetingroom.com")
 
 def build_body(recipient, items):
     lines = []


### PR DESCRIPTION
## Summary
- update the default SERVER_BASE_URL for email templates to use the apecmeetingroom.com domain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e67559ea58832391b1c7ba7192d74b