### PR TITLE
Preserve booking form fields after submission

### DIFF
--- a/app.py
+++ b/app.py
@@ -939,6 +939,7 @@ def create_booking(
 ):
     company = (company or "").strip()
     room = (room or "").strip()
+    email = (email or "").strip()
 
     if date not in EVENT_DATES:
         raise HTTPException(status_code=400, detail="Invalid date")
@@ -993,7 +994,7 @@ def create_booking(
         raise HTTPException(status_code=409, detail="Time slot blocked by administrator")
 
     # --- 저장 ---
-    insert_booking(date, room, tier, company_to_save, email.strip(), start_hour, blocks)
+    insert_booking(date, room, tier, company_to_save, email, start_hour, blocks)
 
     # 리다이렉트(입력 복원)
     params = {
@@ -1003,6 +1004,7 @@ def create_booking(
         "blocks": str(blocks),
         "picked": str(start_hour),
         "company": "Other" if company == "Other" else company_to_save,
+        "email": email,
     }
     if company == "Other":
         params["company_other"] = company_to_save

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -436,7 +436,11 @@ Please contact the administrator if you need assistance outside the stated hours
     }
     const comp = p.get('company');
     if (comp){ $('#company').value = comp; if (comp === 'Other'){ $('#companyOtherField').classList.remove('hidden'); $('#company_other').value = p.get('company_other') || ''; } }
+    const email = p.get('email');
+    if (email){ $('#email').value = email; }
     $('#date').value = p.get('date') || defaultDate();
+    const room = p.get('room');
+    if (room){ $('#room').value = room; }
     const b = parseInt(p.get('blocks')||'1',10); $('#blocks').value = (b===2?'2':'1');
     const ps = p.get('picked'); if(ps !== null) { try { desiredStartFromURL = parseInt(ps,10); } catch(_){} }
   }


### PR DESCRIPTION
## Summary
- trim and persist the submitted email when saving a booking
- include the email in the post-booking redirect so the booking page can restore it
- restore the room and email fields from query parameters when the booking page reloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67bde03d08323acda2aea974f7f20